### PR TITLE
Choosing semigroup

### DIFF
--- a/src/Control/Carrier/NonDet/Church.hs
+++ b/src/Control/Carrier/NonDet/Church.hs
@@ -8,7 +8,6 @@ module Control.Carrier.NonDet.Church
 , runNonDet
 , NonDetC(..)
   -- * Re-exports
-, oneOf
 , Carrier
 , Member
 , run
@@ -24,7 +23,6 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Maybe (fromJust)
-import Data.Monoid
 
 -- | Run a 'NonDet' effect, collecting all branches’ results into an 'Alternative' functor.
 --
@@ -34,20 +32,6 @@ import Data.Monoid
 --   prop> run (runNonDet (pure a)) === Just a
 runNonDet :: (Alternative f, Applicative m) => NonDetC m a -> m (f a)
 runNonDet (NonDetC m) = m (liftA2 (<|>)) (pure . pure) (pure empty)
-
--- | Nondeterministically choose an element from a 'Foldable' collection.
--- This can be used to emulate the style of nondeterminism associated with
--- programming in the list monad:
--- @
---   pythagoreanTriples = do
---     a <- oneOf [1..10]
---     b <- oneOf [1..10]
---     c <- oneOf [1..10]
---     guard (a^2 + b^2 == c^2)
---     pure (a, b, c)
--- @
-oneOf :: (Foldable t, Alternative m) => t a -> m a
-oneOf = getAlt . foldMap (Alt . pure)
 
 -- | A carrier for 'NonDet' effects based on Ralf Hinze’s design described in [Deriving Backtracking Monad Transformers](https://www.cs.ox.ac.uk/ralf.hinze/publications/#P12).
 newtype NonDetC m a = NonDetC

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -7,7 +7,8 @@ module Control.Effect.Choose
 , many
 , some
 , some1
-  -- * Choosing semigroup
+, oneOf
+-- * Choosing semigroup
 , Choosing(..)
 ) where
 
@@ -44,6 +45,20 @@ some a = (:) <$> a <*> many a
 some1 :: (Carrier sig m, Member Choose sig) => m a -> m (NonEmpty a)
 some1 a = (:|) <$> a <*> many a
 
+
+-- | Nondeterministically choose an element from a 'Foldable' collection.
+-- This can be used to emulate the style of nondeterminism associated with
+-- programming in the list monad:
+-- @
+--   pythagoreanTriples = do
+--     a <- oneOf [1..10]
+--     b <- oneOf [1..10]
+--     c <- oneOf [1..10]
+--     guard (a^2 + b^2 == c^2)
+--     pure (a, b, c)
+-- @
+oneOf :: (Foldable t, Carrier sig m, Member Choose sig, Member Empty sig) => t a -> m a
+oneOf = getChoosing . foldMap (Choosing . pure)
 
 newtype Choosing m a = Choosing { getChoosing :: m a }
 

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -7,6 +7,8 @@ module Control.Effect.Choose
 , many
 , some
 , some1
+  -- * Choosing semigroup
+, Choosing(..)
 ) where
 
 import Control.Carrier.Class
@@ -40,3 +42,6 @@ some a = (:) <$> a <*> many a
 -- | One or more, returning a 'NonEmpty' list of the results.
 some1 :: (Carrier sig m, Member Choose sig) => m a -> m (NonEmpty a)
 some1 a = (:|) <$> a <*> many a
+
+
+newtype Choosing m a = Choosing { getChoosing :: m a }

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -12,6 +12,7 @@ module Control.Effect.Choose
 ) where
 
 import Control.Carrier.Class
+import Control.Effect.Empty
 import Data.Bool (bool)
 import Data.List.NonEmpty (NonEmpty (..))
 import GHC.Generics (Generic1)
@@ -48,3 +49,6 @@ newtype Choosing m a = Choosing { getChoosing :: m a }
 
 instance (Carrier sig m, Member Choose sig) => Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (choose m1 m2)
+
+instance (Carrier sig m, Member Choose sig, Member Empty sig) => Monoid (Choosing m a) where
+  mempty = Choosing (send Empty)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -15,6 +15,7 @@ module Control.Effect.Choose
 import Control.Carrier.Class
 import Control.Effect.Empty
 import Data.Bool (bool)
+import Data.Coerce
 import Data.List.NonEmpty (NonEmpty (..))
 import GHC.Generics (Generic1)
 
@@ -58,7 +59,7 @@ some1 a = (:|) <$> a <*> many a
 --     pure (a, b, c)
 -- @
 oneOf :: (Foldable t, Carrier sig m, Member Choose sig, Member Empty sig) => t a -> m a
-oneOf = getChoosing . foldMap (Choosing . pure)
+oneOf = getChoosing #. foldMap (Choosing #. pure)
 
 newtype Choosing m a = Choosing { getChoosing :: m a }
 
@@ -67,3 +68,8 @@ instance (Carrier sig m, Member Choose sig) => Semigroup (Choosing m a) where
 
 instance (Carrier sig m, Member Choose sig, Member Empty sig) => Monoid (Choosing m a) where
   mempty = Choosing (send Empty)
+
+
+(#.) :: Coercible b c => (b -> c) -> (a -> b) -> (a -> c)
+(#.) _ = coerce
+{-# INLINE (#.) #-}

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -45,3 +45,6 @@ some1 a = (:|) <$> a <*> many a
 
 
 newtype Choosing m a = Choosing { getChoosing :: m a }
+
+instance (Carrier sig m, Member Choose sig) => Semigroup (Choosing m a) where
+  Choosing m1 <> Choosing m2 = Choosing (choose m1 m2)


### PR DESCRIPTION
This PR adds a `Semigroup`/`Monoid` using `Choose`/`Empty` instead of `Alternative` to define `oneOf`.