### PR TITLE
Bridging instances

### DIFF
--- a/diffused-effects.cabal
+++ b/diffused-effects.cabal
@@ -26,7 +26,8 @@ common common
 
 library
   import:              common
-  exposed-modules:     Control.Algebra.Choose.Church
+  exposed-modules:     Control.Algebra
+                     , Control.Algebra.Choose.Church
                      , Control.Algebra.Class
                      , Control.Algebra.Cull
                      , Control.Algebra.Cut.Church

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, GeneralizedNewtypeDeriving, UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, UndecidableInstances #-}
 module Control.Algebra
 ( Effects(..)
 ) where
@@ -16,6 +16,9 @@ newtype Effects m a = Effects { runEffects :: m a }
 
 instance MonadTrans Effects where
   lift = Effects
+
+instance Algebra sig m => Algebra sig (Effects m) where
+  alg = Effects . alg . handleCoercible
 
 instance (Algebra sig m, Member Effect.Fail sig) => Fail.MonadFail (Effects m) where
   fail = lift . Effect.fail

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -15,4 +15,4 @@ instance MonadTrans Effects where
   lift = Effects
 
 instance (Algebra sig m, Member Effect.Fail sig) => Fail.MonadFail (Effects m) where
-  fail = Effects . Effect.fail
+  fail = lift . Effect.fail

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -8,6 +8,7 @@ import           Control.Algebra.Class
 import qualified Control.Effect.Choose as Effect
 import qualified Control.Effect.Empty as Effect
 import qualified Control.Effect.Fail as Effect
+import           Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail
 import           Control.Monad.Trans.Class
 
@@ -26,3 +27,5 @@ instance (Algebra sig m, Member Effect.Fail sig) => Fail.MonadFail (Effects m) w
 instance (Algebra sig m, Member Effect.Choose sig, Member Effect.Empty sig) => Alternative.Alternative (Effects m) where
   empty = Effect.empty
   (<|>) = (Effect.<|>)
+
+instance (Algebra sig m, Member Effect.Choose sig, Member Effect.Empty sig) => MonadPlus (Effects m)

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -6,9 +6,13 @@ module Control.Algebra
 import           Control.Algebra.Class
 import qualified Control.Effect.Fail as Effect
 import qualified Control.Monad.Fail as Fail
+import           Control.Monad.Trans.Class
 
 newtype Effects m a = Effects { runEffects :: m a }
   deriving (Applicative, Functor, Monad)
+
+instance MonadTrans Effects where
+  lift = Effects
 
 instance (Algebra sig m, Member Effect.Fail sig) => Fail.MonadFail (Effects m) where
   fail = Effects . Effect.fail

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -21,8 +21,8 @@ instance Algebra sig m => Algebra sig (Effects m) where
   alg = Effects . alg . handleCoercible
 
 instance (Algebra sig m, Member Effect.Fail sig) => Fail.MonadFail (Effects m) where
-  fail = lift . Effect.fail
+  fail = Effect.fail
 
 instance (Algebra sig m, Member Effect.Choose sig, Member Effect.Empty sig) => Alternative.Alternative (Effects m) where
-  empty = lift Effect.empty
-  Effects l <|> Effects r = Effects (l Effect.<|> r)
+  empty = Effect.empty
+  (<|>) = (Effect.<|>)

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -3,7 +3,10 @@ module Control.Algebra
 ( Effects(..)
 ) where
 
+import qualified Control.Applicative as Alternative
 import           Control.Algebra.Class
+import qualified Control.Effect.Choose as Effect
+import qualified Control.Effect.Empty as Effect
 import qualified Control.Effect.Fail as Effect
 import qualified Control.Monad.Fail as Fail
 import           Control.Monad.Trans.Class
@@ -16,3 +19,7 @@ instance MonadTrans Effects where
 
 instance (Algebra sig m, Member Effect.Fail sig) => Fail.MonadFail (Effects m) where
   fail = lift . Effect.fail
+
+instance (Algebra sig m, Member Effect.Choose sig, Member Effect.Empty sig) => Alternative.Alternative (Effects m) where
+  empty = lift Effect.empty
+  Effects l <|> Effects r = Effects (l Effect.<|> r)

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,7 +1,14 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleContexts, GeneralizedNewtypeDeriving, UndecidableInstances #-}
 module Control.Algebra
 ( Effects(..)
 ) where
 
+import           Control.Algebra.Class
+import qualified Control.Effect.Fail as Effect
+import qualified Control.Monad.Fail as Fail
+
 newtype Effects m a = Effects { runEffects :: m a }
   deriving (Applicative, Functor, Monad)
+
+instance (Algebra sig m, Member Effect.Fail sig) => Fail.MonadFail (Effects m) where
+  fail = Effects . Effect.fail

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,2 +1,5 @@
 module Control.Algebra
-() where
+( Effects(..)
+) where
+
+newtype Effects m a = Effects { runEffects :: m a }

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Control.Algebra
 ( Effects(..)
 ) where
 
 newtype Effects m a = Effects { runEffects :: m a }
+  deriving (Applicative, Functor, Monad)

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,0 +1,2 @@
+module Control.Algebra
+() where

--- a/src/Control/Algebra/Cull.hs
+++ b/src/Control/Algebra/Cull.hs
@@ -11,17 +11,11 @@ module Control.Algebra.Cull
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Algebra.NonDet.Church
 import Control.Algebra.Reader
 import Control.Effect.Cull
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
-import Data.Bool (bool)
 
 -- | Run a 'Cull' effect. Branches outside of any 'cull' block will not be pruned.
 --
@@ -30,15 +24,7 @@ runCull :: (m b -> m b -> m b) -> (a -> m b) -> m b -> CullC m a -> m b
 runCull fork leaf nil (CullC m) = runNonDetC (runReader False m) fork leaf nil
 
 newtype CullC m a = CullC { runCullC :: ReaderC Bool (NonDetC m) a }
-  deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO)
-
-instance (Algebra sig m, Effect sig) => Alternative (CullC m) where
-  empty = send Empty
-  {-# INLINE empty #-}
-  l <|> r = send (Choose (bool r l))
-  {-# INLINE (<|>) #-}
-
-instance (Algebra sig m, Effect sig) => MonadPlus (CullC m)
+  deriving (Applicative, Functor, Monad)
 
 instance MonadTrans CullC where
   lift = CullC . lift . lift
@@ -46,12 +32,12 @@ instance MonadTrans CullC where
 
 instance (Algebra sig m, Effect sig) => Algebra (Cull :+: Empty :+: Choose :+: sig) (CullC m) where
   alg (L (Cull m k))         = CullC (local (const True) (runCullC m)) >>= k
-  alg (R (L Empty))          = CullC empty
+  alg (R (L Empty))          = CullC (send Empty)
   alg (R (R (L (Choose k)))) = CullC $ ReaderC $ \ cull ->
     if cull then
       NonDetC $ \ fork leaf nil ->
         runNonDetC (runReader cull (runCullC (k True))) fork leaf (runNonDetC (runReader cull (runCullC (k False))) fork leaf nil)
     else
-      runReader cull (runCullC (k True)) <|> runReader cull (runCullC (k False))
+      choose (runReader cull (runCullC (k True))) (runReader cull (runCullC (k False)))
   alg (R (R (R other)))      = CullC (alg (R (R (R (handleCoercible other)))))
   {-# INLINE alg #-}

--- a/src/Control/Algebra/Cull.hs
+++ b/src/Control/Algebra/Cull.hs
@@ -26,8 +26,8 @@ import Data.Bool (bool)
 -- | Run a 'Cull' effect. Branches outside of any 'cull' block will not be pruned.
 --
 --   prop> run (runNonDet (runCull (pure a <|> pure b))) === [a, b]
-runCull :: Alternative m => CullC m a -> m a
-runCull (CullC m) = runNonDetC (runReader False m) (<|>) pure empty
+runCull :: (m b -> m b -> m b) -> (a -> m b) -> m b -> CullC m a -> m b
+runCull fork leaf nil (CullC m) = runNonDetC (runReader False m) fork leaf nil
 
 newtype CullC m a = CullC { runCullC :: ReaderC Bool (NonDetC m) a }
   deriving (Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO)

--- a/src/Control/Algebra/Cut/Church.hs
+++ b/src/Control/Algebra/Cut/Church.hs
@@ -28,8 +28,8 @@ import Prelude hiding (fail)
 -- | Run a 'Cut' effect within an underlying 'Alternative' instance (typically another 'Algebra' for 'Choose' & 'Empty' effects).
 --
 --   prop> run (runNonDetOnce (runCut (pure a))) === Just a
-runCut :: Alternative m => CutC m a -> m a
-runCut m = runCutC m ((<|>) . pure) empty empty
+runCut :: (a -> m b -> m b) -> m b -> m b -> CutC m a -> m b
+runCut cons nil cutfail (CutC m) = m cons nil cutfail
 
 -- | Run a 'Cut' effect, returning all its results in an 'Alternative' collection.
 runCutAll :: (Alternative f, Applicative m) => CutC m a -> m (f a)

--- a/src/Control/Algebra/Cut/Church.hs
+++ b/src/Control/Algebra/Cut/Church.hs
@@ -22,7 +22,6 @@ import Control.Monad.Fix
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Bool (bool)
-import Prelude hiding (fail)
 
 -- | Run a 'Cut' effect within an underlying 'Alternative' instance (typically another 'Algebra' for 'Choose' & 'Empty' effects).
 --

--- a/src/Control/Algebra/Empty/Maybe.hs
+++ b/src/Control/Algebra/Empty/Maybe.hs
@@ -18,7 +18,7 @@ import Control.Monad.Trans.Class
 
 -- | Run an 'Empty' effect, returning 'Nothing' for empty computations, or 'Just' the result otherwise.
 --
---   prop> run (runEmpty abort)    === Nothing
+--   prop> run (runEmpty empty)    === Nothing
 --   prop> run (runEmpty (pure a)) === Just a
 runEmpty :: EmptyC m a -> m (Maybe a)
 runEmpty = runEmptyC

--- a/src/Control/Algebra/Empty/Maybe.hs
+++ b/src/Control/Algebra/Empty/Maybe.hs
@@ -11,13 +11,9 @@ module Control.Algebra.Empty.Maybe
 , run
 ) where
 
-import Control.Applicative (Alternative (..), liftA2)
+import Control.Applicative (liftA2)
 import Control.Algebra.Class
 import Control.Effect.Empty
-import Control.Monad (MonadPlus (..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 -- | Run an 'Empty' effect, returning 'Nothing' for empty computations, or 'Just' the result otherwise.
@@ -36,31 +32,9 @@ instance Applicative m => Applicative (EmptyC m) where
   EmptyC f <*> EmptyC a = EmptyC (liftA2 (<*>) f a)
   {-# INLINE (<*>) #-}
 
--- $
---   prop> run (runEmpty empty) === Nothing
-instance Applicative m => Alternative (EmptyC m) where
-  empty = EmptyC (pure Nothing)
-  {-# INLINE empty #-}
-  EmptyC a <|> EmptyC b = EmptyC (liftA2 (<|>) a b)
-  {-# INLINE (<|>) #-}
-
 instance Monad m => Monad (EmptyC m) where
   EmptyC a >>= f = EmptyC (a >>= maybe (pure Nothing) (runEmptyC . f))
   {-# INLINE (>>=) #-}
-
-instance Fail.MonadFail m => Fail.MonadFail (EmptyC m) where
-  fail = lift . Fail.fail
-  {-# INLINE fail #-}
-
-instance MonadFix m => MonadFix (EmptyC m) where
-  mfix f = EmptyC (mfix (runEmpty . maybe (error "mfix (EmptyC): function returned failure") f))
-  {-# INLINE mfix #-}
-
-instance MonadIO m => MonadIO (EmptyC m) where
-  liftIO = lift . liftIO
-  {-# INLINE liftIO #-}
-
-instance (Alternative m, Monad m) => MonadPlus (EmptyC m)
 
 instance MonadTrans EmptyC where
   lift = EmptyC . fmap Just

--- a/src/Control/Algebra/Fail.hs
+++ b/src/Control/Algebra/Fail.hs
@@ -8,18 +8,12 @@ module Control.Algebra.Fail
   -- * Re-exports
 , Algebra
 , Member
-, Fail.MonadFail(..)
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Algebra.Error.Either
 import Control.Effect.Fail
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 -- | Run a 'Fail' effect, returning failure messages in 'Left' and successful computations’ results in 'Right'.
@@ -29,11 +23,7 @@ runFail :: FailC m a -> m (Either String a)
 runFail = runError . runFailC
 
 newtype FailC m a = FailC { runFailC :: ErrorC String m a }
-  deriving (Alternative, Applicative, Functor, Monad, MonadFix, MonadIO, MonadPlus, MonadTrans)
-
-instance (Algebra sig m, Effect sig) => Fail.MonadFail (FailC m) where
-  fail s = send (Fail s)
-  {-# INLINE fail #-}
+  deriving (Applicative, Functor, Monad, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Fail :+: sig) (FailC m) where
   alg (L (Fail s)) = FailC (throwError s)

--- a/src/Control/Algebra/Fail.hs
+++ b/src/Control/Algebra/Fail.hs
@@ -32,11 +32,11 @@ newtype FailC m a = FailC { runFailC :: ErrorC String m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Fail.MonadFail (FailC m) where
-  fail s = FailC (throwError s)
+  fail s = send (Fail s)
   {-# INLINE fail #-}
 
 instance (Algebra sig m, Effect sig) => Algebra (Fail :+: sig) (FailC m) where
-  alg (L (Fail s)) = Fail.fail s
+  alg (L (Fail s)) = FailC (throwError s)
   alg (R other)    = FailC (alg (R (handleCoercible other)))
   {-# INLINE alg #-}
 

--- a/src/Control/Algebra/Fresh/Strict.hs
+++ b/src/Control/Algebra/Fresh/Strict.hs
@@ -11,14 +11,9 @@ module Control.Algebra.Fresh.Strict
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Algebra.State.Strict
 import Control.Effect.Fresh
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 -- | Run a 'Fresh' effect counting up from 0.
@@ -29,7 +24,7 @@ runFresh :: Functor m => FreshC m a -> m a
 runFresh = evalState 0 . runFreshC
 
 newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving (Applicative, Functor, Monad, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Fresh :+: sig) (FreshC m) where
   alg (L (Fresh   k)) = FreshC $ do

--- a/src/Control/Algebra/Interpose.hs
+++ b/src/Control/Algebra/Interpose.hs
@@ -14,13 +14,8 @@ module Control.Algebra.Interpose
 , run
 ) where
 
-import Control.Applicative
 import Control.Algebra.Class
 import Control.Algebra.Reader
-import Control.Monad (MonadPlus (..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 -- | 'runInterpose' takes a handler for a given effect (such as 'State' or 'Reader')
@@ -35,7 +30,7 @@ runInterpose :: (forall x . alg m x -> m x) -> InterposeC alg m a -> m a
 runInterpose handler = runReader (Handler handler) . runInterposeC
 
 newtype InterposeC alg m a = InterposeC { runInterposeC :: ReaderC (Handler alg m) m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Applicative, Functor, Monad)
 
 instance MonadTrans (InterposeC alg) where
   lift = InterposeC . lift

--- a/src/Control/Algebra/Interpret.hs
+++ b/src/Control/Algebra/Interpret.hs
@@ -12,13 +12,8 @@ module Control.Algebra.Interpret
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Algebra.State.Strict
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -98,7 +93,7 @@ runInterpretState handler state m =
 
 newtype InterpretC s (sig :: (* -> *) -> * -> *) m a =
   InterpretC { runInterpretC :: m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Applicative, Functor, Monad)
 
 
 instance MonadTrans (InterpretC s sig) where

--- a/src/Control/Algebra/Lift.hs
+++ b/src/Control/Algebra/Lift.hs
@@ -11,14 +11,8 @@ module Control.Algebra.Lift
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Effect.Lift
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
-import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Class
 
 -- | Extract a 'Lift'ed 'Monad'ic action from an effectful computation.
@@ -26,16 +20,10 @@ runM :: LiftC m a -> m a
 runM = runLiftC
 
 newtype LiftC m a = LiftC { runLiftC :: m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Applicative, Functor, Monad)
 
 instance MonadTrans LiftC where
   lift = LiftC
 
 instance Monad m => Algebra (Lift m) (LiftC m) where
   alg = LiftC . (>>= runLiftC) . unLift
-
-instance MonadUnliftIO m => MonadUnliftIO (LiftC m) where
-  askUnliftIO = LiftC $ withUnliftIO $ \u -> return (UnliftIO (unliftIO u . runLiftC))
-  {-# INLINE askUnliftIO #-}
-  withRunInIO inner = LiftC $ withRunInIO $ \run -> inner (run . runLiftC)
-  {-# INLINE withRunInIO #-}

--- a/src/Control/Algebra/Resumable/Abort.hs
+++ b/src/Control/Algebra/Resumable/Abort.hs
@@ -12,15 +12,10 @@ module Control.Algebra.Resumable.Abort
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Algebra.Error.Either
 import Control.DeepSeq
 import Control.Effect.Resumable
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Functor.Classes
 
@@ -31,7 +26,7 @@ runResumable :: ResumableC err m a -> m (Either (SomeError err) a)
 runResumable = runError . runResumableC
 
 newtype ResumableC err m a = ResumableC { runResumableC :: ErrorC (SomeError err) m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving (Applicative, Functor, Monad, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Resumable err :+: sig) (ResumableC err m) where
   alg (L (Resumable err _)) = ResumableC (throwError (SomeError err))

--- a/src/Control/Algebra/Resumable/Resume.hs
+++ b/src/Control/Algebra/Resumable/Resume.hs
@@ -11,14 +11,9 @@ module Control.Algebra.Resumable.Resume
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Algebra.Reader
 import Control.Effect.Resumable
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 -- | Run a 'Resumable' effect, resuming uncaught errors with a given handler.
@@ -36,7 +31,7 @@ runResumable
 runResumable with = runReader (Handler with) . runResumableC
 
 newtype ResumableC err m a = ResumableC { runResumableC :: ReaderC (Handler err m) m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Applicative, Functor, Monad)
 
 instance MonadTrans (ResumableC err) where
   lift = ResumableC . lift

--- a/src/Control/Algebra/State/Lazy.hs
+++ b/src/Control/Algebra/State/Lazy.hs
@@ -13,13 +13,8 @@ module Control.Algebra.State.Lazy
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Effect.State as State
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
@@ -44,26 +39,6 @@ instance Monad m => Monad (StateC s m) where
     ~(s', a) <- runStateC m s
     runStateC (k a) s'
   {-# INLINE (>>=) #-}
-
-instance (Alternative m, Monad m) => Alternative (StateC s m) where
-  empty = StateC (const empty)
-  {-# INLINE empty #-}
-  StateC l <|> StateC r = StateC (\ s -> l s <|> r s)
-  {-# INLINE (<|>) #-}
-
-instance Fail.MonadFail m => Fail.MonadFail (StateC s m) where
-  fail s = StateC (const (Fail.fail s))
-  {-# INLINE fail #-}
-
-instance MonadFix m => MonadFix (StateC s m) where
-  mfix f = StateC (\ s -> mfix (runState s . f . snd))
-  {-# INLINE mfix #-}
-
-instance MonadIO m => MonadIO (StateC s m) where
-  liftIO io = StateC (\ s -> (,) s <$> liftIO io)
-  {-# INLINE liftIO #-}
-
-instance (Alternative m, Monad m) => MonadPlus (StateC s m)
 
 instance MonadTrans (StateC s) where
   lift m = StateC (\ s -> (,) s <$> m)

--- a/src/Control/Algebra/State/Strict.hs
+++ b/src/Control/Algebra/State/Strict.hs
@@ -13,13 +13,8 @@ module Control.Algebra.State.Strict
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Effect.State
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 -- | Run a 'State' effect starting from the passed value.
@@ -59,32 +54,12 @@ instance Monad m => Applicative (StateC s m) where
   m *> k = m >>= \_ -> k
   {-# INLINE (*>) #-}
 
-instance (Alternative m, Monad m) => Alternative (StateC s m) where
-  empty = StateC (const empty)
-  {-# INLINE empty #-}
-  StateC l <|> StateC r = StateC (\ s -> l s <|> r s)
-  {-# INLINE (<|>) #-}
-
 instance Monad m => Monad (StateC s m) where
   StateC m >>= f = StateC $ \ s -> do
     (s', a) <- m s
     let fa = f a
     fa `seq` runState s' fa
   {-# INLINE (>>=) #-}
-
-instance Fail.MonadFail m => Fail.MonadFail (StateC s m) where
-  fail s = StateC (const (Fail.fail s))
-  {-# INLINE fail #-}
-
-instance MonadFix m => MonadFix (StateC s m) where
-  mfix f = StateC (\ s -> mfix (runState s . f . snd))
-  {-# INLINE mfix #-}
-
-instance MonadIO m => MonadIO (StateC s m) where
-  liftIO io = StateC (\ s -> (,) s <$> liftIO io)
-  {-# INLINE liftIO #-}
-
-instance (Alternative m, Monad m) => MonadPlus (StateC s m)
 
 instance MonadTrans (StateC s) where
   lift m = StateC (\ s -> (,) s <$> m)

--- a/src/Control/Algebra/Trace/Ignoring.hs
+++ b/src/Control/Algebra/Trace/Ignoring.hs
@@ -11,13 +11,8 @@ module Control.Algebra.Trace.Ignoring
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Effect.Trace
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 -- | Run a 'Trace' effect, ignoring all traces.
@@ -27,7 +22,7 @@ runTrace :: TraceC m a -> m a
 runTrace = runTraceC
 
 newtype TraceC m a = TraceC { runTraceC :: m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus)
+  deriving (Applicative, Functor, Monad)
 
 instance MonadTrans TraceC where
   lift = TraceC

--- a/src/Control/Algebra/Trace/Returning.hs
+++ b/src/Control/Algebra/Trace/Returning.hs
@@ -11,14 +11,9 @@ module Control.Algebra.Trace.Returning
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Algebra.State.Strict
 import Control.Effect.Trace
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Bifunctor (first)
 
@@ -29,7 +24,7 @@ runTrace :: Functor m => TraceC m a -> m ([String], a)
 runTrace = fmap (first reverse) . runState [] . runTraceC
 
 newtype TraceC m a = TraceC { runTraceC :: StateC [String] m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving (Applicative, Functor, Monad, MonadTrans)
 
 instance (Algebra sig m, Effect sig) => Algebra (Trace :+: sig) (TraceC m) where
   alg (L (Trace m k)) = TraceC (modify (m :)) *> k

--- a/src/Control/Algebra/Writer/Strict.hs
+++ b/src/Control/Algebra/Writer/Strict.hs
@@ -12,14 +12,9 @@ module Control.Algebra.Writer.Strict
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
 import Control.Algebra.Class
 import Control.Algebra.State.Strict
 import Control.Effect.Writer
-import Control.Monad (MonadPlus(..))
-import qualified Control.Monad.Fail as Fail
-import Control.Monad.Fix
-import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 
 -- | Run a 'Writer' effect with a 'Monoid'al log, producing the final log alongside the result value.
@@ -41,7 +36,7 @@ execWriter = fmap fst . runWriter
 --
 --   This is based on a post Gabriel Gonzalez made to the Haskell mailing list: https://mail.haskell.org/pipermail/libraries/2013-March/019528.html
 newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
-  deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
+  deriving (Applicative, Functor, Monad, MonadTrans)
 
 instance (Monoid w, Algebra sig m, Effect sig) => Algebra (Writer w :+: sig) (WriterC w m) where
   alg (L (Tell w     k)) = WriterC $ do

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -3,9 +3,11 @@ module Control.Effect.Empty
 ( -- * Empty effect
   Empty(..)
 , abort
+, guard
 ) where
 
 import Control.Algebra.Class
+import Data.Bool (bool)
 import GHC.Generics (Generic1)
 
 -- | An effect modelling nondeterminism without choice.
@@ -22,3 +24,6 @@ instance Effect   Empty
 --   prop> run (runEmpty abort) === Nothing
 abort :: (Algebra sig m, Member Empty sig) => m a
 abort = send Empty
+
+guard :: (Algebra sig m, Member Empty sig) => Bool -> m ()
+guard = bool abort (pure ())

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -2,7 +2,7 @@
 module Control.Effect.Empty
 ( -- * Empty effect
   Empty(..)
-, abort
+, empty
 , guard
 ) where
 
@@ -21,9 +21,9 @@ instance Effect   Empty
 
 -- | Abort the computation.
 --
---   prop> run (runEmpty abort) === Nothing
-abort :: (Algebra sig m, Member Empty sig) => m a
-abort = send Empty
+--   prop> run (runEmpty empty) === Nothing
+empty :: (Algebra sig m, Member Empty sig) => m a
+empty = send Empty
 
 guard :: (Algebra sig m, Member Empty sig) => Bool -> m ()
-guard = bool abort (pure ())
+guard = bool empty (pure ())

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -1,14 +1,19 @@
-{-# LANGUAGE DeriveFunctor, DeriveGeneric, KindSignatures #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, KindSignatures #-}
 module Control.Effect.Fail
 ( -- * Fail effect
   Fail(..)
+, fail
 ) where
 
 import Control.Algebra.Class
 import GHC.Generics (Generic1)
+import Prelude hiding (fail)
 
 newtype Fail (m :: * -> *) k = Fail String
   deriving (Functor, Generic1)
 
 instance HFunctor Fail
 instance Effect   Fail
+
+fail :: (Algebra sig m, Member Fail sig) => String -> m a
+fail = send . Fail


### PR DESCRIPTION
This PR 🔥s all the `MonadFail`, `Alternative`, etc, instances, and introduces an `Effects` newtype to make them available again via the various effect interfaces.

Not yet included: `MonadIO`, `MonadUnliftIO`. These are a bit weird because we will probably to specialize `Member` for a unique terminal occurrence of `Lift` in order to allow `(Algebra sig m, LastMember (Lift n) sig, MonadIO n)` to imply `MonadIO (Effects m)` unambiguously.