### PR TITLE
Symbolic effects

### DIFF
--- a/diffused-effects.cabal
+++ b/diffused-effects.cabal
@@ -67,6 +67,7 @@ library
                      , Control.Effect.State
                      , Control.Effect.State.Named
                      , Control.Effect.Sum
+                     , Control.Effect.Sum.Named
                      , Control.Effect.Trace
                      , Control.Effect.Writer
   build-depends:       base           >= 4.9 && < 4.14

--- a/diffused-effects.cabal
+++ b/diffused-effects.cabal
@@ -38,6 +38,7 @@ library
                      , Control.Algebra.Interpose
                      , Control.Algebra.Interpret
                      , Control.Algebra.Lift
+                     , Control.Algebra.Named
                      , Control.Algebra.NonDet.Church
                      , Control.Algebra.Pure
                      , Control.Algebra.Reader

--- a/diffused-effects.cabal
+++ b/diffused-effects.cabal
@@ -26,7 +26,8 @@ common common
 
 library
   import:              common
-  exposed-modules:     Control.Algebra.Choose.Church
+  exposed-modules:     Control.Algebra
+                     , Control.Algebra.Choose.Church
                      , Control.Algebra.Class
                      , Control.Algebra.Cull
                      , Control.Algebra.Cut.Church

--- a/diffused-effects.cabal
+++ b/diffused-effects.cabal
@@ -63,6 +63,7 @@ library
                      , Control.Effect.Lift
                      , Control.Effect.Pure
                      , Control.Effect.Reader
+                     , Control.Effect.Reader.Named
                      , Control.Effect.Resource
                      , Control.Effect.Resumable
                      , Control.Effect.State

--- a/diffused-effects.cabal
+++ b/diffused-effects.cabal
@@ -65,6 +65,7 @@ library
                      , Control.Effect.Resource
                      , Control.Effect.Resumable
                      , Control.Effect.State
+                     , Control.Effect.State.Named
                      , Control.Effect.Sum
                      , Control.Effect.Trace
                      , Control.Effect.Writer

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,2 +1,8 @@
 module Control.Algebra
-() where
+( -- * Re-exports
+  module Control.Algebra.Class
+, module Control.Effect.Class
+) where
+
+import Control.Algebra.Class
+import Control.Effect.Class

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -3,8 +3,10 @@ module Control.Algebra
   module Control.Algebra.Class
 , module Control.Effect.Class
 , module Control.Effect.Sum
+, run
 ) where
 
 import Control.Algebra.Class
+import Control.Algebra.Pure
 import Control.Effect.Class
 import Control.Effect.Sum

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -2,7 +2,9 @@ module Control.Algebra
 ( -- * Re-exports
   module Control.Algebra.Class
 , module Control.Effect.Class
+, module Control.Effect.Sum
 ) where
 
 import Control.Algebra.Class
 import Control.Effect.Class
+import Control.Effect.Sum

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,0 +1,2 @@
+module Control.Algebra
+() where

--- a/src/Control/Algebra/Choose/Church.hs
+++ b/src/Control/Algebra/Choose/Church.hs
@@ -11,8 +11,8 @@ module Control.Algebra.Choose.Church
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative ((<|>), liftA2)
-import Control.Algebra.Class
 import Control.Effect.Choose
 import Control.Monad (join)
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Class.hs
+++ b/src/Control/Algebra/Class.hs
@@ -1,17 +1,10 @@
 {-# LANGUAGE DefaultSignatures, DeriveFunctor, EmptyCase, FlexibleContexts, FlexibleInstances, FunctionalDependencies, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Class
 ( Algebra(..)
-, send
--- * Re-exports
-, module Control.Effect.Class
-, Pure.run
-, (Sum.:+:)(..)
-, Sum.Member(..)
 ) where
 
 import qualified Control.Algebra.Pure as Pure
 import           Control.Effect.Class
-import qualified Control.Effect.Sum as Sum
 
 -- | The class of algebras (effect handlers) for carriers (monad transformers) over signatures (effects), whose actions are given by the 'alg' method.
 class (HFunctor sig, Monad m) => Algebra sig m | m -> sig where
@@ -22,9 +15,3 @@ class (HFunctor sig, Monad m) => Algebra sig m | m -> sig where
 instance Algebra Pure.Pure Pure.PureC where
   alg v = case v of {}
   {-# INLINE alg #-}
-
-
--- | Construct a request for an effect to be interpreted by some handler later on.
-send :: (Sum.Member effect sig, Algebra sig m) => effect m a -> m a
-send = alg . Sum.inj
-{-# INLINE send #-}

--- a/src/Control/Algebra/Class.hs
+++ b/src/Control/Algebra/Class.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, DeriveFunctor, EmptyCase, FlexibleContexts, FlexibleInstances, FunctionalDependencies, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
 module Control.Algebra.Class
 ( Algebra(..)
 ) where

--- a/src/Control/Algebra/Class.hs
+++ b/src/Control/Algebra/Class.hs
@@ -3,15 +3,9 @@ module Control.Algebra.Class
 ( Algebra(..)
 ) where
 
-import qualified Control.Algebra.Pure as Pure
-import           Control.Effect.Class
+import Control.Effect.Class
 
 -- | The class of algebras (effect handlers) for carriers (monad transformers) over signatures (effects), whose actions are given by the 'alg' method.
 class (HFunctor sig, Monad m) => Algebra sig m | m -> sig where
   -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
   alg :: sig m a -> m a
-
-
-instance Algebra Pure.Pure Pure.PureC where
-  alg v = case v of {}
-  {-# INLINE alg #-}

--- a/src/Control/Algebra/Cull.hs
+++ b/src/Control/Algebra/Cull.hs
@@ -11,10 +11,10 @@ module Control.Algebra.Cull
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
+import Control.Algebra
 import Control.Algebra.NonDet.Church
 import Control.Algebra.Reader
+import Control.Applicative (Alternative(..))
 import Control.Effect.Cull
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Cut/Church.hs
+++ b/src/Control/Algebra/Cut/Church.hs
@@ -12,8 +12,8 @@ module Control.Algebra.Cut.Church
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
 import Control.Effect.Choose
 import Control.Effect.Cut
 import Control.Effect.Empty

--- a/src/Control/Algebra/Empty/Maybe.hs
+++ b/src/Control/Algebra/Empty/Maybe.hs
@@ -11,8 +11,8 @@ module Control.Algebra.Empty.Maybe
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative (..), liftA2)
-import Control.Algebra.Class
 import Control.Effect.Empty
 import Control.Monad (MonadPlus (..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Error/Either.hs
+++ b/src/Control/Algebra/Error/Either.hs
@@ -11,8 +11,8 @@ module Control.Algebra.Error.Either
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative(..), liftA2)
-import Control.Algebra.Class
 import Control.Effect.Error
 import Control.Monad (MonadPlus(..), (<=<))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Fail.hs
+++ b/src/Control/Algebra/Fail.hs
@@ -12,9 +12,9 @@ module Control.Algebra.Fail
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
+import Control.Algebra
 import Control.Algebra.Error.Either
+import Control.Applicative (Alternative(..))
 import Control.Effect.Fail
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Fresh/Strict.hs
+++ b/src/Control/Algebra/Fresh/Strict.hs
@@ -11,9 +11,9 @@ module Control.Algebra.Fresh.Strict
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
+import Control.Algebra
 import Control.Algebra.State.Strict
+import Control.Applicative (Alternative(..))
 import Control.Effect.Fresh
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Interpose.hs
+++ b/src/Control/Algebra/Interpose.hs
@@ -14,9 +14,9 @@ module Control.Algebra.Interpose
 , run
 ) where
 
-import Control.Applicative
-import Control.Algebra.Class
+import Control.Algebra
 import Control.Algebra.Reader
+import Control.Applicative
 import Control.Monad (MonadPlus (..))
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix

--- a/src/Control/Algebra/Interpret.hs
+++ b/src/Control/Algebra/Interpret.hs
@@ -12,9 +12,9 @@ module Control.Algebra.Interpret
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
+import Control.Algebra
 import Control.Algebra.State.Strict
+import Control.Applicative (Alternative(..))
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix

--- a/src/Control/Algebra/Lift.hs
+++ b/src/Control/Algebra/Lift.hs
@@ -11,8 +11,8 @@ module Control.Algebra.Lift
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
 import Control.Effect.Lift
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Named.hs
+++ b/src/Control/Algebra/Named.hs
@@ -1,0 +1,2 @@
+module Control.Algebra.Named
+() where

--- a/src/Control/Algebra/Named.hs
+++ b/src/Control/Algebra/Named.hs
@@ -1,7 +1,13 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, PolyKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, MultiParamTypeClasses, PolyKinds, UndecidableInstances #-}
 module Control.Algebra.Named
 ( NamedC(..)
 ) where
 
+import Control.Algebra
+import Control.Effect.Sum.Named
+
 newtype NamedC (name :: k) m a = NamedC { runNamed :: m a }
   deriving (Applicative, Functor, Monad)
+
+instance Algebra sig m => Algebra (Named name sig) (NamedC name m) where
+  alg = NamedC . alg . handleCoercible . getNamed

--- a/src/Control/Algebra/Named.hs
+++ b/src/Control/Algebra/Named.hs
@@ -1,2 +1,6 @@
+{-# LANGUAGE PolyKinds #-}
 module Control.Algebra.Named
-() where
+( NamedC(..)
+) where
+
+newtype NamedC (name :: k) m a = NamedC { runNamed :: m a }

--- a/src/Control/Algebra/Named.hs
+++ b/src/Control/Algebra/Named.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, PolyKinds #-}
 module Control.Algebra.Named
 ( NamedC(..)
 ) where
 
 newtype NamedC (name :: k) m a = NamedC { runNamed :: m a }
+  deriving (Applicative, Functor, Monad)

--- a/src/Control/Algebra/NonDet/Church.hs
+++ b/src/Control/Algebra/NonDet/Church.hs
@@ -13,8 +13,8 @@ module Control.Algebra.NonDet.Church
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative(..), liftA2)
-import Control.Algebra.Class
 import Control.Effect.Choose
 import Control.Effect.Empty
 import Control.Monad (MonadPlus(..), join)

--- a/src/Control/Algebra/Pure.hs
+++ b/src/Control/Algebra/Pure.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE EmptyCase, MultiParamTypeClasses #-}
 module Control.Algebra.Pure
 ( -- * Pure effect
   module Control.Effect.Pure
@@ -6,6 +7,7 @@ module Control.Algebra.Pure
 , PureC(..)
 ) where
 
+import Control.Algebra.Class
 import Control.Applicative
 import Control.Effect.Pure
 import Control.Monad.Fix
@@ -51,3 +53,7 @@ instance Monad PureC where
 instance MonadFix PureC where
   mfix f = PureC (fix (runPureC . f))
   {-# INLINE mfix #-}
+
+instance Algebra Pure PureC where
+  alg v = case v of {}
+  {-# INLINE alg #-}

--- a/src/Control/Algebra/Reader.hs
+++ b/src/Control/Algebra/Reader.hs
@@ -11,8 +11,8 @@ module Control.Algebra.Reader
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative(..), liftA2)
-import Control.Algebra.Class
 import Control.Effect.Reader
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Resource.hs
+++ b/src/Control/Algebra/Resource.hs
@@ -11,9 +11,9 @@ module Control.Algebra.Resource
 , run
 ) where
 
-import           Control.Applicative (Alternative(..))
-import           Control.Algebra.Class
+import           Control.Algebra
 import           Control.Algebra.Reader
+import           Control.Applicative (Alternative(..))
 import           Control.Effect.Resource
 import qualified Control.Exception as Exc
 import           Control.Monad (MonadPlus(..))

--- a/src/Control/Algebra/Resumable/Abort.hs
+++ b/src/Control/Algebra/Resumable/Abort.hs
@@ -12,9 +12,9 @@ module Control.Algebra.Resumable.Abort
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
+import Control.Algebra
 import Control.Algebra.Error.Either
+import Control.Applicative (Alternative(..))
 import Control.DeepSeq
 import Control.Effect.Resumable
 import Control.Monad (MonadPlus(..))

--- a/src/Control/Algebra/Resumable/Resume.hs
+++ b/src/Control/Algebra/Resumable/Resume.hs
@@ -11,9 +11,9 @@ module Control.Algebra.Resumable.Resume
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
+import Control.Algebra
 import Control.Algebra.Reader
+import Control.Applicative (Alternative(..))
 import Control.Effect.Resumable
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/State/Lazy.hs
+++ b/src/Control/Algebra/State/Lazy.hs
@@ -13,8 +13,8 @@ module Control.Algebra.State.Lazy
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
 import Control.Effect.State as State
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/State/Strict.hs
+++ b/src/Control/Algebra/State/Strict.hs
@@ -13,8 +13,8 @@ module Control.Algebra.State.Strict
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
 import Control.Effect.State
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Trace/Ignoring.hs
+++ b/src/Control/Algebra/Trace/Ignoring.hs
@@ -11,8 +11,8 @@ module Control.Algebra.Trace.Ignoring
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
 import Control.Effect.Trace
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Trace/Printing.hs
+++ b/src/Control/Algebra/Trace/Printing.hs
@@ -11,8 +11,8 @@ module Control.Algebra.Trace.Printing
 , run
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
 import Control.Effect.Trace
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Trace/Returning.hs
+++ b/src/Control/Algebra/Trace/Returning.hs
@@ -11,9 +11,9 @@ module Control.Algebra.Trace.Returning
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
+import Control.Algebra
 import Control.Algebra.State.Strict
+import Control.Applicative (Alternative(..))
 import Control.Effect.Trace
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Algebra/Writer/Strict.hs
+++ b/src/Control/Algebra/Writer/Strict.hs
@@ -12,9 +12,9 @@ module Control.Algebra.Writer.Strict
 , run
 ) where
 
-import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
+import Control.Algebra
 import Control.Algebra.State.Strict
+import Control.Applicative (Alternative(..))
 import Control.Effect.Writer
 import Control.Monad (MonadPlus(..))
 import qualified Control.Monad.Fail as Fail

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -2,7 +2,7 @@ module Control.Effect
 ( module X
 ) where
 
-import Control.Algebra.Class    as X ((:+:), Algebra, Effect, HFunctor, Member)
+import Control.Algebra          as X ((:+:), Algebra, Effect, HFunctor, Member)
 import Control.Effect.Choose    as X (Choose)
 import Control.Effect.Cull      as X (Cull)
 import Control.Effect.Cut       as X (Cut)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -12,7 +12,7 @@ module Control.Effect.Choose
 , Choosing(..)
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 import Control.Effect.Empty
 import Data.Bool (bool)
 import Data.Coerce

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -5,7 +5,7 @@ module Control.Effect.Cull
 , cull
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 
 -- | 'Cull' effects are used with 'Choose' to provide control over branching.
 data Cull m k

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -7,8 +7,8 @@ module Control.Effect.Cut
 , cut
 ) where
 
+import Control.Algebra
 import Control.Applicative (Alternative(..))
-import Control.Algebra.Class
 
 -- | 'Cut' effects are used with 'Choose' to provide control over backtracking.
 data Cut m k

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -5,7 +5,7 @@ module Control.Effect.Empty
 , abort
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 import GHC.Generics (Generic1)
 
 -- | An effect modelling nondeterminism without choice.

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -6,7 +6,7 @@ module Control.Effect.Error
 , catchError
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 
 data Error exc m k
   = Throw exc

--- a/src/Control/Effect/Fail.hs
+++ b/src/Control/Effect/Fail.hs
@@ -4,7 +4,7 @@ module Control.Effect.Fail
   Fail(..)
 ) where
 
-import Control.Algebra.Class
+import Control.Effect.Class
 import GHC.Generics (Generic1)
 
 newtype Fail (m :: * -> *) k = Fail String

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -6,7 +6,7 @@ module Control.Effect.Fresh
 , resetFresh
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 
 data Fresh m k
   = Fresh (Int -> m k)

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -5,7 +5,7 @@ module Control.Effect.Lift
 , sendM
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 import GHC.Generics
 
 newtype Lift sig m k = Lift { unLift :: sig (m k) }

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -7,7 +7,7 @@ module Control.Effect.Reader
 , local
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 
 data Reader r m k
   = Ask (r -> m k)

--- a/src/Control/Effect/Reader/Named.hs
+++ b/src/Control/Effect/Reader/Named.hs
@@ -1,0 +1,2 @@
+module Control.Effect.Reader.Named
+() where

--- a/src/Control/Effect/Reader/Named.hs
+++ b/src/Control/Effect/Reader/Named.hs
@@ -1,2 +1,6 @@
 module Control.Effect.Reader.Named
-() where
+( -- * Reader effect
+  Reader(..)
+) where
+
+import Control.Effect.Reader (Reader(..))

--- a/src/Control/Effect/Reader/Named.hs
+++ b/src/Control/Effect/Reader/Named.hs
@@ -1,6 +1,31 @@
+{-# LANGUAGE AllowAmbiguousTypes, FlexibleContexts, ScopedTypeVariables, TypeApplications #-}
 module Control.Effect.Reader.Named
 ( -- * Reader effect
   Reader(..)
+, ask
+, asks
+, local
 ) where
 
+import Control.Algebra
+import Control.Effect.Sum.Named
 import Control.Effect.Reader (Reader(..))
+
+-- | Retrieve the environment value.
+--
+--   prop> run (runReader a ask) === a
+ask :: forall name r m sig . (NamedMember name (Reader r) sig, Algebra sig m) => m r
+ask = sendNamed @name (Ask pure)
+
+-- | Project a function out of the current environment value.
+--
+--   prop> snd (run (runReader a (asks (applyFun f)))) === applyFun f a
+asks :: forall name r m a sig . (NamedMember name (Reader r) sig, Algebra sig m) => (r -> a) -> m a
+asks f = sendNamed @name (Ask (pure . f))
+
+-- | Run a computation with an environment value locally modified by the passed function.
+--
+--   prop> run (runReader a (local (applyFun f) ask)) === applyFun f a
+--   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) === (a, applyFun f a, a)
+local :: forall name r m a sig . (NamedMember name (Reader r) sig, Algebra sig m) => (r -> r) -> m a -> m a
+local f m = sendNamed @name (Local f m pure)

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -8,7 +8,7 @@ module Control.Effect.Resource
 , onException
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 
 data Resource m k
   = forall resource any output . Resource (m resource) (resource -> m any) (resource -> m output) (output -> m k)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -5,7 +5,7 @@ module Control.Effect.Resumable
 , throwResumable
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 
 -- | Errors which can be resumed with values of some existentially-quantified type.
 data Resumable err m k

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -9,7 +9,7 @@ module Control.Effect.State
 , modifyLazy
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 import GHC.Generics (Generic1)
 import Prelude hiding (fail)
 

--- a/src/Control/Effect/State/Named.hs
+++ b/src/Control/Effect/State/Named.hs
@@ -1,5 +1,51 @@
+{-# LANGUAGE AllowAmbiguousTypes, FlexibleContexts, ScopedTypeVariables, TypeApplications #-}
 module Control.Effect.State.Named
 ( State(..)
+, get
+, gets
+, put
+, modify
+, modifyLazy
 ) where
 
-import Control.Effect.State
+import Control.Algebra
+import Control.Effect.State (State(..))
+
+-- | Get the current state value.
+--
+--   prop> snd (run (runState a get)) === a
+get :: forall name s m sig . (NamedMember name (State s) sig, Algebra sig m) => m s
+get = sendNamed @name (Get pure)
+{-# INLINEABLE get #-}
+
+-- | Project a function out of the current state value.
+--
+--   prop> snd (run (runState a (gets (applyFun f)))) === applyFun f a
+gets :: forall name s m a sig . (NamedMember name (State s) sig, Algebra sig m) => (s -> a) -> m a
+gets f = sendNamed @name (Get (pure . f))
+{-# INLINEABLE gets #-}
+
+-- | Replace the state value with a new value.
+--
+--   prop> fst (run (runState a (put b))) === b
+--   prop> snd (run (runState a (get <* put b))) === a
+--   prop> snd (run (runState a (put b *> get))) === b
+put :: forall name s m sig . (NamedMember name (State s) sig, Algebra sig m) => s -> m ()
+put s = sendNamed @name (Put s (pure ()))
+{-# INLINEABLE put #-}
+
+-- | Replace the state value with the result of applying a function to the current state value.
+--   This is strict in the new state.
+--
+--   prop> fst (run (runState a (modify (+1)))) === (1 + a :: Integer)
+modify :: forall name s m sig . (NamedMember name (State s) sig, Algebra sig m) => (s -> s) -> m ()
+modify f = do
+  a <- get @name
+  put @name $! f a
+{-# INLINEABLE modify #-}
+
+-- | Replace the state value with the result of applying a function to the current state value.
+--   This is lazy in the new state; injudicious use of this function may lead to space leaks.
+modifyLazy :: forall name s m sig . (NamedMember name (State s) sig, Algebra sig m) => (s -> s) -> m ()
+modifyLazy f = get @name >>= put @name . f
+{-# INLINEABLE modifyLazy #-}

--- a/src/Control/Effect/State/Named.hs
+++ b/src/Control/Effect/State/Named.hs
@@ -1,0 +1,5 @@
+module Control.Effect.State.Named
+( State(..)
+) where
+
+import Control.Effect.State

--- a/src/Control/Effect/State/Named.hs
+++ b/src/Control/Effect/State/Named.hs
@@ -9,6 +9,7 @@ module Control.Effect.State.Named
 ) where
 
 import Control.Algebra
+import Control.Effect.Sum.Named
 import Control.Effect.State (State(..))
 
 -- | Get the current state value.

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE DataKinds, DeriveGeneric, DeriveTraversable, FlexibleInstances, FunctionalDependencies, KindSignatures, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleInstances, FunctionalDependencies, KindSignatures, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum
 ( (:+:)(..)
 , Member(..)
 , send
 , Named(..)
 , NamedMember(..)
+, sendNamed
 ) where
 
 import Control.Algebra.Class
@@ -61,3 +62,9 @@ instance {-# OVERLAPPABLE #-} NamedMember name sub (Named name sub :+: sup) wher
 
 instance {-# OVERLAPPABLE #-} NamedMember name sub sup => NamedMember name sub (sub' :+: sup) where
   injNamed = R . injNamed
+
+
+-- | Construct a request for a named effect to be interpreted by some handler later on.
+sendNamed :: forall name effect sig m a . (NamedMember name effect sig, Algebra sig m) => effect m a -> m a
+sendNamed = alg . injNamed . Named @name
+{-# INLINE sendNamed #-}

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -2,8 +2,10 @@
 module Control.Effect.Sum
 ( (:+:)(..)
 , Member(..)
+, send
 ) where
 
+import Control.Algebra.Class
 import Control.Effect.Class
 import GHC.Generics (Generic1)
 
@@ -35,3 +37,9 @@ instance {-# OVERLAPPABLE #-} Member sub sup => Member sub (sub' :+: sup) where
   inj = R . inj
   prj (R g) = prj g
   prj _     = Nothing
+
+
+-- | Construct a request for an effect to be interpreted by some handler later on.
+send :: (Member effect sig, Algebra sig m) => effect m a -> m a
+send = alg . inj
+{-# INLINE send #-}

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleInstances, FunctionalDependencies, KindSignatures, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators #-}
 module Control.Effect.Sum
 ( (:+:)(..)
 , Member(..)

--- a/src/Control/Effect/Sum/Named.hs
+++ b/src/Control/Effect/Sum/Named.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, DataKinds, FlexibleInstances, FunctionalDependencies, KindSignatures, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, DataKinds, FlexibleInstances, FunctionalDependencies, KindSignatures, PolyKinds, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum.Named
 ( Named(..)
 , NamedMember(..)
@@ -6,12 +6,11 @@ module Control.Effect.Sum.Named
 ) where
 
 import Control.Algebra
-import GHC.TypeLits
 
-newtype Named (name :: Symbol) (eff :: (* -> *) -> (* -> *)) m k = Named { getNamed :: eff m k }
+newtype Named (name :: k) (eff :: (* -> *) -> (* -> *)) m a = Named { getNamed :: eff m a }
 
-class NamedMember (name :: Symbol) sub sup | name sup -> sub where
-  injNamed :: Named name sub m k -> sup m k
+class NamedMember (name :: k) sub sup | name sup -> sub where
+  injNamed :: Named name sub m a -> sup m a
 
 instance NamedMember name sub (Named name sub) where
   injNamed = id

--- a/src/Control/Effect/Sum/Named.hs
+++ b/src/Control/Effect/Sum/Named.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, DataKinds, FlexibleInstances, FunctionalDependencies, KindSignatures, PolyKinds, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, DataKinds, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, KindSignatures, PolyKinds, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum.Named
 ( Named(..)
 , NamedMember(..)
@@ -8,6 +8,8 @@ module Control.Effect.Sum.Named
 import Control.Algebra
 
 newtype Named (name :: k) (eff :: (* -> *) -> (* -> *)) m a = Named { getNamed :: eff m a }
+  deriving (HFunctor, Effect)
+
 
 class NamedMember (name :: k) sub sup | name sup -> sub where
   injNamed :: Named name sub m a -> sup m a

--- a/src/Control/Effect/Sum/Named.hs
+++ b/src/Control/Effect/Sum/Named.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, DataKinds, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, KindSignatures, PolyKinds, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, PolyKinds, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum.Named
 ( Named(..)
 , NamedMember(..)

--- a/src/Control/Effect/Sum/Named.hs
+++ b/src/Control/Effect/Sum/Named.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE AllowAmbiguousTypes, DataKinds, FlexibleInstances, FunctionalDependencies, KindSignatures, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
+module Control.Effect.Sum.Named
+( Named(..)
+, NamedMember(..)
+, sendNamed
+) where
+
+import Control.Algebra
+import GHC.TypeLits
+
+newtype Named (name :: Symbol) (eff :: (* -> *) -> (* -> *)) m k = Named { getNamed :: eff m k }
+
+class NamedMember (name :: Symbol) sub sup | name sup -> sub where
+  injNamed :: Named name sub m k -> sup m k
+
+instance NamedMember name sub (Named name sub) where
+  injNamed = id
+
+instance {-# OVERLAPPABLE #-} NamedMember name sub (Named name sub :+: sup) where
+  injNamed = L
+
+instance {-# OVERLAPPABLE #-} NamedMember name sub sup => NamedMember name sub (sub' :+: sup) where
+  injNamed = R . injNamed
+
+
+-- | Construct a request for a named effect to be interpreted by some handler later on.
+sendNamed :: forall name effect sig m a . (NamedMember name effect sig, Algebra sig m) => effect m a -> m a
+sendNamed = alg . injNamed . Named @name
+{-# INLINE sendNamed #-}

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -5,7 +5,7 @@ module Control.Effect.Trace
 , trace
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 import GHC.Generics (Generic1)
 
 data Trace m k = Trace

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -8,7 +8,7 @@ module Control.Effect.Writer
 , censor
 ) where
 
-import Control.Algebra.Class
+import Control.Algebra
 
 data Writer w m k
   = Tell w (m k)


### PR DESCRIPTION
This PR introduces named effects, demonstrated with smart constructors for `State` using names to improve type inference:

```haskell
λ :t put @"hello" 'a' *> get @"hello"
put @"hello" 'a' *> get @"hello"
  :: (NamedMember "hello" (State Char) sig, Algebra sig f) => f Char
```

We see there is only one `State` effect present for the actions sharing this name, and the action produces `Char`. Contrast this with the type inferred for unnamed `State` effects:

```haskell
λ :t put 'a' *> get
put 'a' *> get
  :: (Algebra sig f, Member (State b) sig,
      Member (State Char) sig) =>
     f b
```

Here, the `put` is correctly inferred to be for a `State Char` effect, but the `get` is unconstrained, with nothing relating it to the `put`’s effect; thus, we have two `Member` constraints and the action produces some unknown type `b` to be constrained by the caller.

Further, having names allows us to make requests for multiple distinct `State` effects for the same state type:

```haskell
λ :t put @"hello" 'a' *> put @"goodbye" 'b' *> get @"hello"
put @"hello" 'a' *> put @"goodbye" 'b' *> get @"hello"
  :: (NamedMember "goodbye" (State Char) sig,
      NamedMember "hello" (State Char) sig, Algebra sig f) =>
     f Char
```

~~We’re still going to need some sort of carrier, I’m ideally thinking we can get one that should work with the standard carriers.~~ **Edit:** `NamedC` exists.