### PR TITLE
Sums as trees

### DIFF
--- a/diffused-effects.cabal
+++ b/diffused-effects.cabal
@@ -61,6 +61,7 @@ library
                      , Control.Effect.Fail
                      , Control.Effect.Fresh
                      , Control.Effect.Lift
+                     , Control.Effect.NonDet
                      , Control.Effect.Pure
                      , Control.Effect.Reader
                      , Control.Effect.Reader.Named

--- a/src/Control/Algebra/Cull.hs
+++ b/src/Control/Algebra/Cull.hs
@@ -48,9 +48,9 @@ instance MonadTrans CullC where
   lift = CullC . lift . lift
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (Cull :+: Empty :+: Choose :+: sig) (CullC m) where
+instance (Algebra sig m, Effect sig) => Algebra (Cull :+: (Empty :+: Choose) :+: sig) (CullC m) where
   alg (L (Cull m k))         = CullC (local (const True) (runCullC m)) >>= k
-  alg (R (L Empty))          = empty
-  alg (R (R (L (Choose k)))) = k True <|> k False
-  alg (R (R (R other)))      = CullC (alg (R (R (R (handleCoercible other)))))
+  alg (R (L (L Empty)))      = empty
+  alg (R (L (R (Choose k)))) = k True <|> k False
+  alg (R (R other))          = CullC (alg (R (R (handleCoercible other))))
   {-# INLINE alg #-}

--- a/src/Control/Algebra/Cull.hs
+++ b/src/Control/Algebra/Cull.hs
@@ -48,7 +48,7 @@ instance MonadTrans CullC where
   lift = CullC . lift . lift
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (Cull :+: (Empty :+: Choose) :+: sig) (CullC m) where
+instance (Algebra sig m, Effect sig) => Algebra (Cull :+: NonDet :+: sig) (CullC m) where
   alg (L (Cull m k))         = CullC (local (const True) (runCullC m)) >>= k
   alg (R (L (L Empty)))      = empty
   alg (R (L (R (Choose k)))) = k True <|> k False

--- a/src/Control/Algebra/NonDet/Church.hs
+++ b/src/Control/Algebra/NonDet/Church.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE DeriveTraversable, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.NonDet.Church
-( -- * Choose effect
-  module Control.Effect.Choose
-  -- * Empty effect
-, module Control.Effect.Empty
+( -- * NonDet effects
+  module Control.Effect.NonDet
   -- * NonDet carrier
 , runNonDet
 , NonDetC(..)
@@ -15,8 +13,7 @@ module Control.Algebra.NonDet.Church
 
 import Control.Algebra
 import Control.Applicative (Alternative(..), liftA2)
-import Control.Effect.Choose
-import Control.Effect.Empty
+import Control.Effect.NonDet
 import Control.Monad (MonadPlus(..), join)
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
@@ -87,7 +84,7 @@ instance MonadTrans NonDetC where
   lift m = NonDetC (\ _ leaf _ -> m >>= leaf)
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra ((Empty :+: Choose) :+: sig) (NonDetC m) where
+instance (Algebra sig m, Effect sig) => Algebra (NonDet :+: sig) (NonDetC m) where
   alg (L (L Empty))      = empty
   alg (L (R (Choose k))) = k True <|> k False
   alg (R other)          = NonDetC $ \ fork leaf nil -> alg (handle (Leaf ()) (fmap join . traverse runNonDet) other) >>= fold fork leaf nil

--- a/src/Control/Algebra/NonDet/Church.hs
+++ b/src/Control/Algebra/NonDet/Church.hs
@@ -87,10 +87,10 @@ instance MonadTrans NonDetC where
   lift m = NonDetC (\ _ leaf _ -> m >>= leaf)
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (Empty :+: Choose :+: sig) (NonDetC m) where
-  alg (L Empty)          = empty
-  alg (R (L (Choose k))) = k True <|> k False
-  alg (R (R other))      = NonDetC $ \ fork leaf nil -> alg (handle (Leaf ()) (fmap join . traverse runNonDet) other) >>= fold fork leaf nil
+instance (Algebra sig m, Effect sig) => Algebra ((Empty :+: Choose) :+: sig) (NonDetC m) where
+  alg (L (L Empty))      = empty
+  alg (L (R (Choose k))) = k True <|> k False
+  alg (R other)          = NonDetC $ \ fork leaf nil -> alg (handle (Leaf ()) (fmap join . traverse runNonDet) other) >>= fold fork leaf nil
   {-# INLINE alg #-}
 
 

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MonoLocalBinds, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Choose
 ( -- * Choose effect
   Choose(..)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MonoLocalBinds, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Choose
 ( -- * Choose effect
   Choose(..)

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -3,9 +3,12 @@ module Control.Effect.Cull
 ( -- * Cull effect
   Cull(..)
 , cull
+  -- * Re-exports
+, module Control.Effect.NonDet
 ) where
 
 import Control.Algebra
+import Control.Effect.NonDet
 
 -- | 'Cull' effects are used with 'Choose' to provide control over branching.
 data Cull m k

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,8 +1,13 @@
+{-# LANGUAGE TypeOperators #-}
 module Control.Effect.NonDet
 ( -- * NonDet effects
   module Control.Effect.Choose
 , module Control.Effect.Empty
+, NonDet
 ) where
 
 import Control.Effect.Choose
 import Control.Effect.Empty
+import Control.Effect.Sum
+
+type NonDet = Choose :+: Empty

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,0 +1,2 @@
+module Control.Effect.NonDet
+() where

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -10,4 +10,4 @@ import Control.Effect.Choose
 import Control.Effect.Empty
 import Control.Effect.Sum
 
-type NonDet = Choose :+: Empty
+type NonDet = Empty :+: Choose

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -1,2 +1,8 @@
 module Control.Effect.NonDet
-() where
+( -- * NonDet effects
+  module Control.Effect.Choose
+, module Control.Effect.Empty
+) where
+
+import Control.Effect.Choose
+import Control.Effect.Empty

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -49,8 +49,9 @@ type family FromJust (maybe :: Maybe a) :: a where
   FromJust ('Just a) = a
 
 type family (left :: Maybe k) <> (right :: Maybe k) :: Maybe k where
-  'Nothing <> b        = b
-  a        <> 'Nothing = a
+  'Just a <> _       = 'Just a
+  _       <> 'Just b = 'Just b
+  _       <> _       = 'Nothing
 
 type family Prepend (s :: j -> k) (ss :: Maybe j) :: Maybe k where
   Prepend s ('Just ss) = 'Just (s ss)

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -68,21 +68,27 @@ type family PathTo sub sup :: [Side] where
   PathTo t (l :+: r) = FromJust (PathTo' 'L_ t l <> PathTo' 'R_ t r)
 
 class ElementAt (path :: [Side]) (sub :: (* -> *) -> (* -> *)) sup where
+  inj' :: sub m a -> sup m a
   prj' :: sup m a -> Maybe (sub m a)
 
 instance ElementAt '[] t t where
+  inj' = id
   prj' = Just
 
 instance ElementAt path t l => ElementAt ('L_ ': path) t (l :+: r) where
+  inj' = L . inj' @path
   prj' (L l) = prj'  @path l
   prj' _     = Nothing
 
 instance ElementAt path t r => ElementAt ('R_ ': path) t (l :+: r) where
+  inj' = R . inj' @path
   prj' (R r) = prj'  @path r
   prj' _     = Nothing
 
 class Element (sub :: (* -> *) -> (* -> *)) sup where
+  inje :: sub m a -> sup m a
   proj :: sup m a -> Maybe (sub m a)
 
 instance (PathTo sub sup ~ path, ElementAt path sub sup) => Element sub sup where
+  inje = inj' @path
   proj = prj' @path

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleInstances, MultiParamTypeClasses, PolyKinds, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleInstances, FunctionalDependencies, PolyKinds, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum
 ( (:+:)(..)
 , Member(..)
@@ -67,7 +67,7 @@ type family PathTo sub sup :: [Side] where
   PathTo t t         = '[]
   PathTo t (l :+: r) = FromJust (PathTo' 'L_ t l <> PathTo' 'R_ t r)
 
-class MemberAt (path :: [Side]) (sub :: (* -> *) -> (* -> *)) sup where
+class MemberAt (path :: [Side]) (sub :: (* -> *) -> (* -> *)) sup | path sup -> sub where
   inj' :: sub m a -> sup m a
   prj' :: sup m a -> Maybe (sub m a)
 

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE AllowAmbiguousTypes, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleInstances, FunctionalDependencies, PolyKinds, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum
 ( (:+:)(..)
-, Member(..)
+, Member
+, inj
+, prj
 , send
 ) where
 

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -52,35 +52,36 @@ type family (left :: Maybe k) <> (right :: Maybe k) :: Maybe k where
   'Nothing <> b        = b
   a        <> 'Nothing = a
 
-type family Prepend (s :: k) (ss :: Maybe [k]) where
-  Prepend s ('Just ss) = 'Just (s ': ss)
+type family Prepend (s :: j -> k) (ss :: Maybe j) :: Maybe k where
+  Prepend s ('Just ss) = 'Just (s ss)
   Prepend _ 'Nothing   = 'Nothing
 
-data Side = L_ | R_
+data L a
+data R a
 
-type family PathTo' (side :: Side) sub sup :: Maybe [Side] where
-  PathTo' s t t         = 'Just '[s]
-  PathTo' s t (l :+: r) = Prepend s (PathTo' 'L_ t l <> PathTo' 'R_ t r)
+type family PathTo' (side :: * -> *) sub sup :: Maybe * where
+  PathTo' s t t         = 'Just (s ())
+  PathTo' s t (l :+: r) = Prepend s (PathTo' L t l <> PathTo' R t r)
   PathTo' _ _ _         = 'Nothing
 
-type family PathTo sub sup :: [Side] where
-  PathTo t t         = '[]
-  PathTo t (l :+: r) = FromJust (PathTo' 'L_ t l <> PathTo' 'R_ t r)
+type family PathTo sub sup where
+  PathTo t t         = ()
+  PathTo t (l :+: r) = FromJust (PathTo' L t l <> PathTo' R t r)
 
-class MemberAt (path :: [Side]) (sub :: (* -> *) -> (* -> *)) sup | path sup -> sub where
+class MemberAt path (sub :: (* -> *) -> (* -> *)) sup | path sup -> sub where
   inj' :: sub m a -> sup m a
   prj' :: sup m a -> Maybe (sub m a)
 
-instance MemberAt '[] t t where
+instance MemberAt () t t where
   inj' = id
   prj' = Just
 
-instance MemberAt path t l => MemberAt ('L_ ': path) t (l :+: r) where
+instance MemberAt path t l => MemberAt (L path) t (l :+: r) where
   inj' = L . inj' @path
   prj' (L l) = prj'  @path l
   prj' _     = Nothing
 
-instance MemberAt path t r => MemberAt ('R_ ': path) t (l :+: r) where
+instance MemberAt path t r => MemberAt (R path) t (l :+: r) where
   inj' = R . inj' @path
   prj' (R r) = prj'  @path r
   prj' _     = Nothing

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -48,10 +48,10 @@ send = alg . inj
 type family FromJust (maybe :: Maybe a) :: a where
   FromJust ('Just a) = a
 
-type family (left :: Maybe k) <> (right :: Maybe k) :: Maybe k where
-  'Just a <> _       = 'Just a
-  _       <> 'Just b = 'Just b
-  _       <> _       = 'Nothing
+type family (left :: Maybe k) <|> (right :: Maybe k) :: Maybe k where
+  'Just a <|> _       = 'Just a
+  _       <|> 'Just b = 'Just b
+  _       <|> _       = 'Nothing
 
 type family Prepend (s :: j -> k) (ss :: Maybe j) :: Maybe k where
   Prepend s ('Just ss) = 'Just (s ss)
@@ -62,12 +62,12 @@ data R a
 
 type family PathTo' (side :: * -> *) sub sup :: Maybe * where
   PathTo' s t t         = 'Just (s ())
-  PathTo' s t (l :+: r) = Prepend s (PathTo' L t l <> PathTo' R t r)
+  PathTo' s t (l :+: r) = Prepend s (PathTo' L t l <|> PathTo' R t r)
   PathTo' _ _ _         = 'Nothing
 
 type family PathTo sub sup where
   PathTo t t         = ()
-  PathTo t (l :+: r) = FromJust (PathTo' L t l <> PathTo' R t r)
+  PathTo t (l :+: r) = FromJust (PathTo' L t l <|> PathTo' R t r)
 
 class MemberAt path (sub :: (* -> *) -> (* -> *)) sup | path sup -> sub where
   inj' :: sub m a -> sup m a

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -67,20 +67,20 @@ type family PathTo sub sup :: [Side] where
   PathTo t t         = '[]
   PathTo t (l :+: r) = FromJust (PathTo' 'L_ t l <> PathTo' 'R_ t r)
 
-class ElementAt (path :: [Side]) (sub :: (* -> *) -> (* -> *)) sup where
+class MemberAt (path :: [Side]) (sub :: (* -> *) -> (* -> *)) sup where
   inj' :: sub m a -> sup m a
   prj' :: sup m a -> Maybe (sub m a)
 
-instance ElementAt '[] t t where
+instance MemberAt '[] t t where
   inj' = id
   prj' = Just
 
-instance ElementAt path t l => ElementAt ('L_ ': path) t (l :+: r) where
+instance MemberAt path t l => MemberAt ('L_ ': path) t (l :+: r) where
   inj' = L . inj' @path
   prj' (L l) = prj'  @path l
   prj' _     = Nothing
 
-instance ElementAt path t r => ElementAt ('R_ ': path) t (l :+: r) where
+instance MemberAt path t r => MemberAt ('R_ ': path) t (l :+: r) where
   inj' = R . inj' @path
   prj' (R r) = prj'  @path r
   prj' _     = Nothing
@@ -89,6 +89,6 @@ class Element (sub :: (* -> *) -> (* -> *)) sup where
   inje :: sub m a -> sup m a
   proj :: sup m a -> Maybe (sub m a)
 
-instance (PathTo sub sup ~ path, ElementAt path sub sup) => Element sub sup where
+instance (PathTo sub sup ~ path, MemberAt path sub sup) => Element sub sup where
   inje = inj' @path
   proj = prj' @path

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -60,7 +60,7 @@ type family Prepend (s :: j -> k) (ss :: Maybe j) :: Maybe k where
 data L a
 data R a
 
-type family PathTo' (side :: * -> *) sub sup :: Maybe * where
+type family PathTo' (side :: * -> *) (sub :: (* -> *) -> (* -> *)) sup :: Maybe * where
   PathTo' s t t         = 'Just (s ())
   PathTo' s t (l :+: r) = Prepend s (PathTo' L t l <|> PathTo' R t r)
   PathTo' _ _ _         = 'Nothing

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -26,19 +26,9 @@ class Member (sub :: (* -> *) -> (* -> *)) sup where
   inj :: sub m a -> sup m a
   prj :: sup m a -> Maybe (sub m a)
 
-instance Member sub sub where
-  inj = id
-  prj = Just
-
-instance {-# OVERLAPPABLE #-} Member sub (sub :+: sup) where
-  inj = L . inj
-  prj (L f) = Just f
-  prj _     = Nothing
-
-instance {-# OVERLAPPABLE #-} Member sub sup => Member sub (sub' :+: sup) where
-  inj = R . inj
-  prj (R g) = prj g
-  prj _     = Nothing
+instance (PathTo sub sup ~ path, MemberAt path sub sup) => Member sub sup where
+  inj = inj' @path
+  prj = prj' @path
 
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
@@ -88,11 +78,3 @@ instance MemberAt path t r => MemberAt (R path) t (l :+: r) where
   inj' = R . inj' @path
   prj' (R r) = prj'  @path r
   prj' _     = Nothing
-
-class Element (sub :: (* -> *) -> (* -> *)) sup where
-  inje :: sub m a -> sup m a
-  proj :: sup m a -> Maybe (sub m a)
-
-instance (PathTo sub sup ~ path, MemberAt path sub sup) => Element sub sup where
-  inje = inj' @path
-  proj = prj' @path

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleInstances, FunctionalDependencies, PolyKinds, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, FunctionalDependencies, PolyKinds, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum
 ( (:+:)(..)
 , Member
@@ -22,13 +22,13 @@ instance (HFunctor f, HFunctor g) => HFunctor (f :+: g)
 instance (Effect f, Effect g)     => Effect   (f :+: g)
 
 
-class Member (sub :: (* -> *) -> (* -> *)) sup where
-  inj :: sub m a -> sup m a
-  prj :: sup m a -> Maybe (sub m a)
+type Member (sub :: (* -> *) -> (* -> *)) sup = MemberAt (PathTo sub sup) sub sup
 
-instance (PathTo sub sup ~ path, MemberAt path sub sup) => Member sub sup where
-  inj = inj' @path
-  prj = prj' @path
+inj :: forall sub m a sup . Member sub sup => sub m a -> sup m a
+inj = inj' @(PathTo sub sup)
+
+prj :: forall sub m a sup . Member sub sup => sup m a -> Maybe (sub m a)
+prj = prj' @(PathTo sub sup)
 
 
 -- | Construct a request for an effect to be interpreted by some handler later on.


### PR DESCRIPTION
This PR allows `Member` to match on the left as well as the right, essentially turning effect lists into effect trees.

This in turn means that we can define a type synonym for `NonDet`, which will match when `Choose :+: Empty` occurs in the tree, while also allowing both `Choose` and `Empty` to match at the same time.