### PR TITLE
Signature as type family

### DIFF
--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -3,10 +3,10 @@ module Main
 ( main
 ) where
 
-import Control.Effect.Algebra
-import Control.Effect.Interpret
-import Control.Effect.Writer
-import Control.Effect.State
+import Control.Algebra
+import Control.Algebra.Interpret
+import Control.Algebra.State.Strict
+import Control.Algebra.Writer.Strict
 import Control.Monad (ap, replicateM_)
 import Data.Functor.Identity
 import Data.Monoid (Sum(..))

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -64,10 +64,10 @@ main = defaultMain
     ]
   ]
 
-tellLoop :: m `Handles` Writer (Sum Int) => Int -> m ()
+tellLoop :: Has Writer (Sum Int) => Int -> m ()
 tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))
 
-modLoop :: m `Handles` (State (Sum Int)) => Int -> m ()
+modLoop :: Has (State (Sum Int)) => Int -> m ()
 modLoop i = replicateM_ i (modify (+ (Sum (1 :: Int))))
 
 newtype Cod m a = Cod { unCod :: forall b . (a -> m b) -> m b }

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, LambdaCase, RankNTypes, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, LambdaCase, RankNTypes, TypeApplications, TypeFamilies, UndecidableInstances #-}
 module Main
 ( main
 ) where

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -64,10 +64,10 @@ main = defaultMain
     ]
   ]
 
-tellLoop :: (Algebra m, Member (Writer (Sum Int)) (Signature m)) => Int -> m ()
+tellLoop :: m `Handles` Writer (Sum Int) => Int -> m ()
 tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))
 
-modLoop :: (Algebra m, Member (State (Sum Int)) (Signature m)) => Int -> m ()
+modLoop :: m `Handles` (State (Sum Int)) => Int -> m ()
 modLoop i = replicateM_ i (modify (+ (Sum (1 :: Int))))
 
 newtype Cod m a = Cod { unCod :: forall b . (a -> m b) -> m b }

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -64,10 +64,10 @@ main = defaultMain
     ]
   ]
 
-tellLoop :: Has Writer (Sum Int) => Int -> m ()
+tellLoop :: Has (Writer (Sum Int)) m => Int -> m ()
 tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))
 
-modLoop :: Has (State (Sum Int)) => Int -> m ()
+modLoop :: Has (State (Sum Int)) m => Int -> m ()
 modLoop i = replicateM_ i (modify (+ (Sum (1 :: Int))))
 
 newtype Cod m a = Cod { unCod :: forall b . (a -> m b) -> m b }

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, RankNTypes, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, LambdaCase, RankNTypes, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Main
 ( main
 ) where
@@ -64,10 +64,10 @@ main = defaultMain
     ]
   ]
 
-tellLoop :: (Algebra sig m, Member (Writer (Sum Int)) sig) => Int -> m ()
+tellLoop :: (Algebra m, Member (Writer (Sum Int)) (Signature m)) => Int -> m ()
 tellLoop i = replicateM_ i (tell (Sum (1 :: Int)))
 
-modLoop :: (Algebra sig m, Member (State (Sum Int)) sig) => Int -> m ()
+modLoop :: (Algebra m, Member (State (Sum Int)) (Signature m)) => Int -> m ()
 modLoop i = replicateM_ i (modify (+ (Sum (1 :: Int))))
 
 newtype Cod m a = Cod { unCod :: forall b . (a -> m b) -> m b }
@@ -83,5 +83,6 @@ instance Applicative (Cod m) where
 instance Monad (Cod m) where
   Cod a >>= f = Cod (\ k -> a (runCod k . f))
 
-instance (Algebra sig m, Effect sig) => Algebra sig (Cod m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (Cod m) where
+  type Signature (Cod m) = Signature m
   alg op = Cod (\ k -> alg (handle (Identity ()) (runCod (pure . Identity) . runIdentity) op) >>= k . runIdentity)

--- a/benchmark/NonDet/NQueens.hs
+++ b/benchmark/NonDet/NQueens.hs
@@ -36,7 +36,7 @@ isSafeIn (i,j) qs = null (diags (i,j) `intersect` underThreat)
     qs' = zip [1..length qs] qs
     underThreat = qs' >>= diags
 
-addOne :: (Member NonDet (Signature m), Algebra m, Alternative m) => Int -> Board -> m Board
+addOne :: (Alternative m, Monad m) => Int -> Board -> m Board
 addOne n curr = do
   let i = length curr + 1
   let choose = asum . fmap pure
@@ -44,7 +44,7 @@ addOne n curr = do
   guard ((i, j) `isSafeIn` curr)
   pure (curr ++ [j])
 
-queens :: (Member NonDet (Signature m), Algebra m, Alternative m) => Int -> m Board
+queens :: (Alternative m, Monad m) => Int -> m Board
 queens n = foldl' (>>=) (pure empty) (replicate n (addOne n))
 
 runQueens :: Int -> [Board]

--- a/benchmark/NonDet/NQueens.hs
+++ b/benchmark/NonDet/NQueens.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DeriveFunctor, FlexibleContexts, FlexibleInstances, LambdaCase, MultiParamTypeClasses, RankNTypes,
-             TypeApplications, TypeOperators, UndecidableInstances #-}
+             TypeApplications, UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- Based largely on the implementation by Sreekar Shastry,

--- a/benchmark/NonDet/NQueens.hs
+++ b/benchmark/NonDet/NQueens.hs
@@ -8,8 +8,7 @@
 module NonDet.NQueens (runQueens, benchmark) where
 
 import Control.Applicative
-import Control.Effect
-import Control.Effect.NonDet
+import Control.Algebra.NonDet.Church
 import Control.Monad
 import Data.Foldable
 import Data.List

--- a/benchmark/NonDet/NQueens.hs
+++ b/benchmark/NonDet/NQueens.hs
@@ -36,7 +36,7 @@ isSafeIn (i,j) qs = null (diags (i,j) `intersect` underThreat)
     qs' = zip [1..length qs] qs
     underThreat = qs' >>= diags
 
-addOne :: (Member NonDet sig, Algebra sig m, Alternative m) => Int -> Board -> m Board
+addOne :: (Member NonDet (Signature m), Algebra m, Alternative m) => Int -> Board -> m Board
 addOne n curr = do
   let i = length curr + 1
   let choose = asum . fmap pure
@@ -44,7 +44,7 @@ addOne n curr = do
   guard ((i, j) `isSafeIn` curr)
   pure (curr ++ [j])
 
-queens :: (Member NonDet sig, Algebra sig m, Alternative m) => Int -> m Board
+queens :: (Member NonDet (Signature m), Algebra m, Alternative m) => Int -> m Board
 queens n = foldl' (>>=) (pure empty) (replicate n (addOne n))
 
 runQueens :: Int -> [Board]

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -4,9 +4,9 @@ module Parser
 ) where
 
 import Control.Algebra
-import Control.Effect.Cut
-import Control.Effect.NonDet
-import Control.Effect.State
+import Control.Algebra.Cut.Church
+import Control.Algebra.NonDet.Church
+import Control.Algebra.State.Strict
 import Control.Monad (replicateM)
 import Data.Char
 import Data.List (intercalate)
@@ -98,7 +98,7 @@ newtype ParseC m a = ParseC { runParseC :: StateC String m a }
   deriving newtype (Alternative, Applicative, Functor, Monad)
 
 instance (Alternative m, Algebra m, Effect (Signature m)) => Algebra (ParseC m) where
-  type Signature (ParserC m) = Symbol :+: Signature m
+  type Signature (ParseC m) = Symbol :+: Signature m
   alg (L (Satisfy p k)) = do
     input <- ParseC get
     case input of

--- a/examples/Parser.hs
+++ b/examples/Parser.hs
@@ -76,16 +76,16 @@ data Symbol m k = Satisfy (Char -> Bool) (Char -> m k)
   deriving stock (Functor, Generic1)
   deriving anyclass (HFunctor, Effect)
 
-satisfy :: m `Handles` Symbol => (Char -> Bool) -> m Char
+satisfy :: Has Symbol m => (Char -> Bool) -> m Char
 satisfy p = send (Satisfy p pure)
 
-char :: m `Handles` Symbol => Char -> m Char
+char :: Has Symbol m => Char -> m Char
 char = satisfy . (==)
 
-digit :: m `Handles` Symbol => m Char
+digit :: Has Symbol m => m Char
 digit = satisfy isDigit
 
-parens :: m `Handles` Symbol => m a -> m a
+parens :: Has Symbol m => m a -> m a
 parens m = char '(' *> m <* char ')'
 
 
@@ -108,19 +108,19 @@ instance (Alternative m, Algebra m, Effect (Signature m)) => Algebra (ParseC m) 
   {-# INLINE alg #-}
 
 
-expr :: (Alternative m, m `Handles` Cut, m `Handles` Symbol) => m Int
+expr :: (Alternative m, Has Cut m, Has Symbol m) => m Int
 expr = do
   i <- term
   call ((i +) <$ char '+' <* cut <*> expr
     <|> pure i)
 
-term :: (Alternative m, m `Handles` Cut, m `Handles` Symbol) => m Int
+term :: (Alternative m, Has Cut m, Has Symbol m) => m Int
 term = do
   i <- factor
   call ((i *) <$ char '*' <* cut <*> term
     <|> pure i)
 
-factor :: (Alternative m, m `Handles` Cut, m `Handles` Symbol) => m Int
+factor :: (Alternative m, Has Cut m, Has Symbol m) => m Int
 factor
   =   read <$> some digit
   <|> parens expr

--- a/examples/ReinterpretLog.hs
+++ b/examples/ReinterpretLog.hs
@@ -64,10 +64,7 @@ renderLogMessage = \case
   Info  message -> "[info] "  ++ message
 
 -- The application: it logs two messages, then quits.
-application ::
-     ( Algebra m
-     , Member (Log Message) (Signature m)
-     )
+application :: m `Handles` Log Message
   => m ()
 application = do
   log (Debug "debug message")
@@ -113,10 +110,7 @@ data Log (a :: Type) (m :: Type -> Type) (k :: Type)
   deriving anyclass (HFunctor, Effect)
 
 -- Log an 'a'.
-log ::
-     ( Algebra m
-     , Member (Log a) (Signature m)
-     )
+log :: m `Handles` Log a
   => a
   -> m ()
 log x =
@@ -169,9 +163,7 @@ newtype ReinterpretLogC s t m a
 instance
      -- So long as the 'm' monad can interpret the 'Signature m' effects, one of which
      -- is 'Log t'...
-     ( Algebra m
-     , Member (Log t) (Signature m)
-     )
+     m `Handles` Log t
      -- ... the 'ReinterpretLogC s t m' monad can interpret 'Log s :+: Signature m'
      -- effects
   => Algebra (ReinterpretLogC s t m) where

--- a/examples/ReinterpretLog.hs
+++ b/examples/ReinterpretLog.hs
@@ -64,7 +64,7 @@ renderLogMessage = \case
   Info  message -> "[info] "  ++ message
 
 -- The application: it logs two messages, then quits.
-application :: m `Handles` Log Message
+application :: Has (Log Message) m
   => m ()
 application = do
   log (Debug "debug message")
@@ -110,7 +110,7 @@ data Log (a :: Type) (m :: Type -> Type) (k :: Type)
   deriving anyclass (HFunctor, Effect)
 
 -- Log an 'a'.
-log :: m `Handles` Log a
+log :: Has (Log a) m
   => a
   -> m ()
 log x =
@@ -163,7 +163,7 @@ newtype ReinterpretLogC s t m a
 instance
      -- So long as the 'm' monad can interpret the 'Signature m' effects, one of which
      -- is 'Log t'...
-     m `Handles` Log t
+     Has (Log t) m
      -- ... the 'ReinterpretLogC s t m' monad can interpret 'Log s :+: Signature m'
      -- effects
   => Algebra (ReinterpretLogC s t m) where

--- a/examples/ReinterpretLog.hs
+++ b/examples/ReinterpretLog.hs
@@ -33,10 +33,10 @@ module ReinterpretLog
   , runApplication
   ) where
 
-import Control.Effect.Algebra
-import Control.Effect.Lift
-import Control.Effect.Reader
-import Control.Effect.Writer
+import Control.Algebra
+import Control.Algebra.Lift
+import Control.Algebra.Reader
+import Control.Algebra.Writer.Strict
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Function          ((&))
 import Data.Kind              (Type)

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -32,10 +32,10 @@ data Teletype m k
   deriving stock (Functor, Generic1)
   deriving anyclass (HFunctor, Effect)
 
-read :: (Member Teletype (Signature m), Algebra m) => m String
+read :: m `Handles` Teletype => m String
 read = send (Read pure)
 
-write :: (Member Teletype (Signature m), Algebra m) => String -> m ()
+write :: m `Handles` Teletype => String -> m ()
 write s = send (Write s (pure ()))
 
 

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -7,9 +7,9 @@ module Teletype
 
 import Prelude hiding (read)
 
-import Control.Effect.Algebra
-import Control.Effect.State
-import Control.Effect.Writer
+import Control.Algebra
+import Control.Algebra.State.Strict
+import Control.Algebra.Writer.Strict
 import Control.Monad.IO.Class
 import GHC.Generics (Generic1)
 import Test.Hspec

--- a/examples/Teletype.hs
+++ b/examples/Teletype.hs
@@ -32,10 +32,10 @@ data Teletype m k
   deriving stock (Functor, Generic1)
   deriving anyclass (HFunctor, Effect)
 
-read :: m `Handles` Teletype => m String
+read :: Has Teletype m => m String
 read = send (Read pure)
 
-write :: m `Handles` Teletype => String -> m ()
+write :: Has Teletype m => String -> m ()
 write s = send (Write s (pure ()))
 
 

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -2,9 +2,9 @@
 module Control.Algebra
 ( -- * Re-exports
   module Control.Algebra.Class
+, module Control.Algebra.Pure
 , module Control.Effect.Class
 , module Control.Effect.Sum
-, run
 , Handles
 , send
 ) where

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,12 +1,22 @@
+{-# LANGUAGE ConstraintKinds, FlexibleContexts, TypeOperators #-}
 module Control.Algebra
 ( -- * Re-exports
   module Control.Algebra.Class
 , module Control.Effect.Class
 , module Control.Effect.Sum
 , run
+, Handles
+, send
 ) where
 
 import Control.Algebra.Class
 import Control.Algebra.Pure
 import Control.Effect.Class
 import Control.Effect.Sum
+
+type Handles m effect = (Member effect (Signature m), Algebra m)
+
+-- | Construct a request for an effect to be interpreted by some handler later on.
+send :: m `Handles` effect => effect m a -> m a
+send = alg . inj
+{-# INLINE send #-}

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE ConstraintKinds, FlexibleContexts, TypeOperators #-}
+{-# LANGUAGE ConstraintKinds, FlexibleContexts #-}
 module Control.Algebra
 ( -- * Re-exports
   module Control.Algebra.Class
 , module Control.Algebra.Pure
 , module Control.Effect.Class
 , (:+:)(..)
-, Handles
+, Has
 , send
 ) where
 
@@ -14,9 +14,9 @@ import Control.Algebra.Pure
 import Control.Effect.Class
 import Control.Effect.Sum
 
-type Handles m effect = (Member effect (Signature m), Algebra m)
+type Has effect m = (Member effect (Signature m), Algebra m)
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
-send :: m `Handles` effect => effect m a -> m a
+send :: Has effect m => effect m a -> m a
 send = alg . inj
 {-# INLINE send #-}

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators #-}
+{-# LANGUAGE ConstraintKinds, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Algebra
 ( -- * Re-exports
   module Control.Algebra.Class
@@ -14,7 +14,7 @@ import Control.Algebra.Pure
 import Control.Effect.Class
 import Control.Effect.Sum
 
-type Has eff m = HasIn (Signature m) eff m
+type Has eff m = (Algebra m, HasIn (Signature m) eff)
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
 send :: Has eff m => eff m a -> m a
@@ -22,6 +22,6 @@ send = alg . inj
 {-# INLINE send #-}
 
 
-class (Algebra m, Member eff sig) => HasIn sig eff m
-instance {-# OVERLAPPABLE #-} Algebra m => HasIn eff eff m
-instance {-# OVERLAPPABLE #-} (Algebra m, Member eff (l :+: r)) => HasIn (l :+: r) eff m
+class Member eff sig => HasIn sig eff
+instance {-# OVERLAPPABLE #-} HasIn eff eff
+instance {-# OVERLAPPABLE #-} Member eff (l :+: r) => HasIn (l :+: r) eff

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -4,7 +4,7 @@ module Control.Algebra
   module Control.Algebra.Class
 , module Control.Algebra.Pure
 , module Control.Effect.Class
-, module Control.Effect.Sum
+, (:+:)(..)
 , Handles
 , send
 ) where

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ConstraintKinds, FlexibleContexts #-}
+{-# LANGUAGE ConstraintKinds, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators #-}
 module Control.Algebra
 ( -- * Re-exports
   module Control.Algebra.Class
@@ -14,9 +14,14 @@ import Control.Algebra.Pure
 import Control.Effect.Class
 import Control.Effect.Sum
 
-type Has eff m = (Member eff (Signature m), Algebra m)
+type Has eff m = HasIn (Signature m) eff m
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
 send :: Has eff m => eff m a -> m a
 send = alg . inj
 {-# INLINE send #-}
+
+
+class (Algebra m, Member eff sig) => HasIn sig eff m
+instance {-# OVERLAPPABLE #-} (Algebra m, Member eff (l :+: r)) => HasIn (l :+: r) eff m
+instance {-# OVERLAPPABLE #-} Algebra m => HasIn eff eff m

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -23,5 +23,5 @@ send = alg . inj
 
 
 class (Algebra m, Member eff sig) => HasIn sig eff m
-instance {-# OVERLAPPABLE #-} (Algebra m, Member eff (l :+: r)) => HasIn (l :+: r) eff m
 instance {-# OVERLAPPABLE #-} Algebra m => HasIn eff eff m
+instance {-# OVERLAPPABLE #-} (Algebra m, Member eff (l :+: r)) => HasIn (l :+: r) eff m

--- a/src/Control/Algebra.hs
+++ b/src/Control/Algebra.hs
@@ -14,9 +14,9 @@ import Control.Algebra.Pure
 import Control.Effect.Class
 import Control.Effect.Sum
 
-type Has effect m = (Member effect (Signature m), Algebra m)
+type Has eff m = (Member eff (Signature m), Algebra m)
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
-send :: Has effect m => effect m a -> m a
+send :: Has eff m => eff m a -> m a
 send = alg . inj
 {-# INLINE send #-}

--- a/src/Control/Algebra/Choose/Church.hs
+++ b/src/Control/Algebra/Choose/Church.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveTraversable, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveTraversable, FlexibleInstances, RankNTypes, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Choose.Church
 ( -- * Choose effect
   module Control.Effect.Choose
@@ -63,7 +63,8 @@ instance MonadTrans ChooseC where
   lift m = ChooseC (\ _ leaf -> m >>= leaf)
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (Choose :+: sig) (ChooseC m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (ChooseC m) where
+  type Signature (ChooseC m) = Choose :+: Signature m
   alg (L (Choose k)) = ChooseC $ \ fork leaf -> fork (runChooseC (k True) fork leaf) (runChooseC (k False) fork leaf)
   alg (R other)      = ChooseC $ \ fork leaf -> alg (handle (Leaf ()) (fmap join . traverse (runChoose (liftA2 Fork) (pure . Leaf))) other) >>= fold fork leaf
   {-# INLINE alg #-}

--- a/src/Control/Algebra/Choose/Church.hs
+++ b/src/Control/Algebra/Choose/Church.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Choose.Church
 , runChoose
 , ChooseC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Choose/Church.hs
+++ b/src/Control/Algebra/Choose/Church.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Choose.Church
 , runChoose
 , ChooseC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Choose/Church.hs
+++ b/src/Control/Algebra/Choose/Church.hs
@@ -50,7 +50,7 @@ instance Fail.MonadFail m => Fail.MonadFail (ChooseC m) where
 instance MonadFix m => MonadFix (ChooseC m) where
   mfix f = ChooseC $ \ fork leaf ->
     mfix (runChoose (liftA2 Fork) (pure . Leaf)
-      . f . fromJust . fold (<|>) Just)
+      . f . fromJust . fold (Control.Applicative.<|>) Just)
     >>= fold fork leaf
   {-# INLINE mfix #-}
 

--- a/src/Control/Algebra/Class.hs
+++ b/src/Control/Algebra/Class.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleContexts, TypeFamilies #-}
 module Control.Algebra.Class
 ( Algebra(..)
 ) where
@@ -6,6 +6,7 @@ module Control.Algebra.Class
 import Control.Effect.Class
 
 -- | The class of algebras (effect handlers) for carriers (monad transformers) over signatures (effects), whose actions are given by the 'alg' method.
-class (HFunctor sig, Monad m) => Algebra sig m | m -> sig where
+class (HFunctor (Signature m), Monad m) => Algebra m where
+  type Signature m :: (* -> *) -> (* -> *)
   -- | Construct a value in the carrier for an effect signature (typically a sum of a handled effect and any remaining effects).
-  alg :: sig m a -> m a
+  alg :: Signature m m a -> m a

--- a/src/Control/Algebra/Cull.hs
+++ b/src/Control/Algebra/Cull.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Cull
 , runCull
 , CullC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Cull.hs
+++ b/src/Control/Algebra/Cull.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Cull
 , runCull
 , CullC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Cull.hs
+++ b/src/Control/Algebra/Cull.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Cull
 ( -- * Cull effect
   module Control.Effect.Cull
@@ -48,7 +48,8 @@ instance MonadTrans CullC where
   lift = CullC . lift . lift
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (Cull :+: NonDet :+: sig) (CullC m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (CullC m) where
+  type Signature (CullC m) = Cull :+: NonDet :+: Signature m
   alg (L (Cull m k))         = CullC (local (const True) (runCullC m)) >>= k
   alg (R (L (L Empty)))      = empty
   alg (R (L (R (Choose k)))) = k True <|> k False

--- a/src/Control/Algebra/Cut/Church.hs
+++ b/src/Control/Algebra/Cut/Church.hs
@@ -7,7 +7,7 @@ module Control.Algebra.Cut.Church
 , runCutAll
 , CutC(..)
 -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Cut/Church.hs
+++ b/src/Control/Algebra/Cut/Church.hs
@@ -7,8 +7,7 @@ module Control.Algebra.Cut.Church
 , runCutAll
 , CutC(..)
 -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Cut/Church.hs
+++ b/src/Control/Algebra/Cut/Church.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleInstances, RankNTypes, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Cut.Church
 ( -- * Cut effect
   module Control.Effect.Cut
@@ -76,7 +76,8 @@ instance MonadTrans CutC where
   lift m = CutC (\ cons nil _ -> m >>= flip cons nil)
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (Cut :+: Empty :+: Choose :+: sig) (CutC m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (CutC m) where
+  type Signature (CutC m) = Cut :+: Empty :+: Choose :+: Signature m
   alg (L Cutfail)    = CutC $ \ _    _   fail -> fail
   alg (L (Call m k)) = CutC $ \ cons nil fail -> runCutC m (\ a as -> runCutC (k a) cons as fail) nil nil
   alg (R (L Empty))          = empty

--- a/src/Control/Algebra/Empty/Maybe.hs
+++ b/src/Control/Algebra/Empty/Maybe.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Empty.Maybe
 , runEmpty
 , EmptyC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Empty/Maybe.hs
+++ b/src/Control/Algebra/Empty/Maybe.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleInstances, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Empty.Maybe
 ( -- * Empty effect
   module Control.Effect.Empty
@@ -66,7 +66,8 @@ instance MonadTrans EmptyC where
   lift = EmptyC . fmap Just
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (Empty :+: sig) (EmptyC m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (EmptyC m) where
+  type Signature (EmptyC m) = Empty :+: Signature m
   alg (L Empty) = EmptyC (pure Nothing)
   alg (R other) = EmptyC (alg (handle (Just ()) (maybe (pure Nothing) runEmptyC) other))
   {-# INLINE alg #-}

--- a/src/Control/Algebra/Empty/Maybe.hs
+++ b/src/Control/Algebra/Empty/Maybe.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Empty.Maybe
 , runEmpty
 , EmptyC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Error/Either.hs
+++ b/src/Control/Algebra/Error/Either.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleInstances, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Error.Either
 ( -- * Error effect
   module Control.Effect.Error
@@ -63,7 +63,8 @@ instance MonadTrans (ErrorC e) where
   lift = ErrorC . fmap Right
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (Error e :+: sig) (ErrorC e m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (ErrorC e m) where
+  type Signature (ErrorC e m) = Error e :+: Signature m
   alg (L (Throw e))     = ErrorC (pure (Left e))
   alg (L (Catch m h k)) = ErrorC (runError m >>= either (either (pure . Left) (runError . k) <=< runError . h) (runError . k))
   alg (R other)         = ErrorC (alg (handle (Right ()) (either (pure . Left) runError) other))

--- a/src/Control/Algebra/Error/Either.hs
+++ b/src/Control/Algebra/Error/Either.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Error.Either
 , runError
 , ErrorC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Error/Either.hs
+++ b/src/Control/Algebra/Error/Either.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Error.Either
 , runError
 , ErrorC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Fail.hs
+++ b/src/Control/Algebra/Fail.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Fail
 ( -- * Fail effect
   module Control.Effect.Fail
@@ -31,11 +31,12 @@ runFail = runError . runFailC
 newtype FailC m a = FailC { runFailC :: ErrorC String m a }
   deriving (Alternative, Applicative, Functor, Monad, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
-instance (Algebra sig m, Effect sig) => Fail.MonadFail (FailC m) where
+instance (Algebra m, Effect (Signature m)) => Fail.MonadFail (FailC m) where
   fail s = FailC (throwError s)
   {-# INLINE fail #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (Fail :+: sig) (FailC m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (FailC m) where
+  type Signature (FailC m) = Fail :+: Signature m
   alg (L (Fail s)) = Fail.fail s
   alg (R other)    = FailC (alg (R (handleCoercible other)))
   {-# INLINE alg #-}

--- a/src/Control/Algebra/Fail.hs
+++ b/src/Control/Algebra/Fail.hs
@@ -2,12 +2,12 @@
 module Control.Algebra.Fail
 ( -- * Fail effect
   module Control.Effect.Fail
+, Fail.MonadFail(..)
   -- * Fail carrier
 , runFail
 , FailC(..)
   -- * Re-exports
-, Handles
-, Fail.MonadFail(..)
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Fail.hs
+++ b/src/Control/Algebra/Fail.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Fail
 , runFail
 , FailC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , Fail.MonadFail(..)
 , run
 ) where

--- a/src/Control/Algebra/Fresh/Strict.hs
+++ b/src/Control/Algebra/Fresh/Strict.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Fresh.Strict
 , runFresh
 , FreshC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Fresh/Strict.hs
+++ b/src/Control/Algebra/Fresh/Strict.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Fresh.Strict
 , runFresh
 , FreshC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Fresh/Strict.hs
+++ b/src/Control/Algebra/Fresh/Strict.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Fresh.Strict
 ( -- * Fresh effect
   module Control.Effect.Fresh
@@ -31,7 +31,8 @@ runFresh = evalState 0 . runFreshC
 newtype FreshC m a = FreshC { runFreshC :: StateC Int m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
-instance (Algebra sig m, Effect sig) => Algebra (Fresh :+: sig) (FreshC m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (FreshC m) where
+  type Signature (FreshC m) = Fresh :+: Signature m
   alg (L (Fresh   k)) = FreshC $ do
     i <- get
     put (succ i)

--- a/src/Control/Algebra/Interpose.hs
+++ b/src/Control/Algebra/Interpose.hs
@@ -9,7 +9,7 @@ module Control.Algebra.Interpose
 ( InterposeC (..)
 , runInterpose
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 
@@ -45,7 +45,7 @@ newtype Handler alg m = Handler (forall x . alg m x -> m x)
 runHandler :: (HFunctor alg, Functor m) => Handler alg m -> alg (ReaderC (Handler alg m) m) a -> m a
 runHandler h@(Handler handler) = handler . hmap (runReader h)
 
-instance (HFunctor alg, m `Handles` alg) => Algebra (InterposeC alg m) where
+instance (HFunctor alg, Has alg m) => Algebra (InterposeC alg m) where
   type Signature (InterposeC alg m) = Signature m
   alg (op :: Signature m (InterposeC alg m) a)
     | Just (op' :: alg (InterposeC alg m) a) <- prj op = do

--- a/src/Control/Algebra/Interpose.hs
+++ b/src/Control/Algebra/Interpose.hs
@@ -9,14 +9,14 @@ module Control.Algebra.Interpose
 ( InterposeC (..)
 , runInterpose
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 
 import Control.Algebra
 import Control.Algebra.Reader
 import Control.Applicative
+import Control.Effect.Sum
 import Control.Monad (MonadPlus (..))
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
@@ -45,7 +45,7 @@ newtype Handler alg m = Handler (forall x . alg m x -> m x)
 runHandler :: (HFunctor alg, Functor m) => Handler alg m -> alg (ReaderC (Handler alg m) m) a -> m a
 runHandler h@(Handler handler) = handler . hmap (runReader h)
 
-instance (HFunctor alg, Algebra m, Member alg (Signature m)) => Algebra (InterposeC alg m) where
+instance (HFunctor alg, m `Handles` alg) => Algebra (InterposeC alg m) where
   type Signature (InterposeC alg m) = Signature m
   alg (op :: Signature m (InterposeC alg m) a)
     | Just (op' :: alg (InterposeC alg m) a) <- prj op = do

--- a/src/Control/Algebra/Interpret.hs
+++ b/src/Control/Algebra/Interpret.hs
@@ -7,7 +7,7 @@ module Control.Algebra.Interpret
 , Reifies
 , Handler
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Interpret.hs
+++ b/src/Control/Algebra/Interpret.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, KindSignatures, RankNTypes, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, KindSignatures, RankNTypes, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
 
 module Control.Algebra.Interpret
 ( runInterpret
@@ -105,7 +105,8 @@ instance MonadTrans (InterpretC s sig) where
   lift = InterpretC
 
 
-instance (HFunctor alg, HFunctor sig, Reifies s (Handler alg m), Monad m, Algebra sig m) => Algebra (alg :+: sig) (InterpretC s alg m) where
+instance (HFunctor alg, Reifies s (Handler alg m), Monad m, Algebra m) => Algebra (InterpretC s alg m) where
+  type Signature (InterpretC s alg m) = alg :+: Signature m
   alg (L alg) =
     runHandler (unTag (reflect @s)) alg
   alg (R other) =

--- a/src/Control/Algebra/Interpret.hs
+++ b/src/Control/Algebra/Interpret.hs
@@ -7,8 +7,7 @@ module Control.Algebra.Interpret
 , Reifies
 , Handler
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Lift.hs
+++ b/src/Control/Algebra/Lift.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Lift
 , runM
 , LiftC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Lift.hs
+++ b/src/Control/Algebra/Lift.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, TypeFamilies #-}
 module Control.Algebra.Lift
 ( -- * Lift effect
   module Control.Effect.Lift
@@ -31,7 +31,8 @@ newtype LiftC m a = LiftC { runLiftC :: m a }
 instance MonadTrans LiftC where
   lift = LiftC
 
-instance Monad m => Algebra (Lift m) (LiftC m) where
+instance Monad m => Algebra (LiftC m) where
+  type Signature (LiftC m) = Lift m
   alg = LiftC . (>>= runLiftC) . unLift
 
 instance MonadUnliftIO m => MonadUnliftIO (LiftC m) where

--- a/src/Control/Algebra/Lift.hs
+++ b/src/Control/Algebra/Lift.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Lift
 , runM
 , LiftC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/NonDet/Church.hs
+++ b/src/Control/Algebra/NonDet/Church.hs
@@ -6,7 +6,7 @@ module Control.Algebra.NonDet.Church
 , runNonDet
 , NonDetC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/NonDet/Church.hs
+++ b/src/Control/Algebra/NonDet/Church.hs
@@ -6,8 +6,7 @@ module Control.Algebra.NonDet.Church
 , runNonDet
 , NonDetC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/NonDet/Church.hs
+++ b/src/Control/Algebra/NonDet/Church.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveTraversable, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveTraversable, FlexibleInstances, RankNTypes, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.NonDet.Church
 ( -- * NonDet effects
   module Control.Effect.NonDet
@@ -84,7 +84,8 @@ instance MonadTrans NonDetC where
   lift m = NonDetC (\ _ leaf _ -> m >>= leaf)
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (NonDet :+: sig) (NonDetC m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (NonDetC m) where
+  type Signature (NonDetC m) = NonDet :+: Signature m
   alg (L (L Empty))      = empty
   alg (L (R (Choose k))) = k True <|> k False
   alg (R other)          = NonDetC $ \ fork leaf nil -> alg (handle (Leaf ()) (fmap join . traverse runNonDet) other) >>= fold fork leaf nil

--- a/src/Control/Algebra/Pure.hs
+++ b/src/Control/Algebra/Pure.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE EmptyCase, MultiParamTypeClasses #-}
+{-# LANGUAGE EmptyCase, TypeFamilies #-}
 module Control.Algebra.Pure
 ( -- * Pure effect
   module Control.Effect.Pure
@@ -54,6 +54,7 @@ instance MonadFix PureC where
   mfix f = PureC (fix (runPureC . f))
   {-# INLINE mfix #-}
 
-instance Algebra Pure PureC where
+instance Algebra PureC where
+  type Signature PureC = Pure
   alg v = case v of {}
   {-# INLINE alg #-}

--- a/src/Control/Algebra/Reader.hs
+++ b/src/Control/Algebra/Reader.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Reader
 , runReader
 , ReaderC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Reader.hs
+++ b/src/Control/Algebra/Reader.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, FlexibleInstances, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Reader
 ( -- * Reader effect
   module Control.Effect.Reader
@@ -75,7 +75,8 @@ instance MonadUnliftIO m => MonadUnliftIO (ReaderC r m) where
   withRunInIO inner = ReaderC $ \r -> withRunInIO $ \go -> inner (go . runReader r)
   {-# INLINE withRunInIO #-}
 
-instance Algebra sig m => Algebra (Reader r :+: sig) (ReaderC r m) where
+instance Algebra m => Algebra (ReaderC r m) where
+  type Signature (ReaderC r m) = Reader r :+: Signature m
   alg (L (Ask       k)) = ReaderC (\ r -> runReader r (k r))
   alg (L (Local f m k)) = ReaderC (\ r -> runReader (f r) m) >>= k
   alg (R other)         = ReaderC (\ r -> alg (hmap (runReader r) other))

--- a/src/Control/Algebra/Reader.hs
+++ b/src/Control/Algebra/Reader.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Reader
 , runReader
 , ReaderC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Resource.hs
+++ b/src/Control/Algebra/Resource.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Resource
 , runResource
 , ResourceC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Resource.hs
+++ b/src/Control/Algebra/Resource.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, RankNTypes, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Resource
 ( -- * Resource effect
   module Control.Effect.Resource
@@ -58,7 +58,8 @@ instance MonadTrans ResourceC where
 runUnlifting :: UnliftIO m -> ResourceC m a -> IO a
 runUnlifting h@(UnliftIO handler) = handler . runReader h . runResourceC
 
-instance (Algebra sig m, MonadIO m) => Algebra (Resource :+: sig) (ResourceC m) where
+instance (Algebra m, MonadIO m) => Algebra (ResourceC m) where
+  type Signature (ResourceC m) = Resource :+: Signature m
   alg (L (Resource acquire release use k)) = do
     handler <- ResourceC ask
     a <- liftIO (Exc.bracket

--- a/src/Control/Algebra/Resource.hs
+++ b/src/Control/Algebra/Resource.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Resource
 , runResource
 , ResourceC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Resumable/Abort.hs
+++ b/src/Control/Algebra/Resumable/Abort.hs
@@ -7,8 +7,7 @@ module Control.Algebra.Resumable.Abort
 , ResumableC(..)
 , SomeError(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Resumable/Abort.hs
+++ b/src/Control/Algebra/Resumable/Abort.hs
@@ -7,7 +7,7 @@ module Control.Algebra.Resumable.Abort
 , ResumableC(..)
 , SomeError(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Resumable/Abort.hs
+++ b/src/Control/Algebra/Resumable/Abort.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ExistentialQuantification, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE ExistentialQuantification, FlexibleInstances, GeneralizedNewtypeDeriving, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Resumable.Abort
 ( -- * Resumable effect
   module Control.Effect.Resumable
@@ -33,7 +33,8 @@ runResumable = runError . runResumableC
 newtype ResumableC err m a = ResumableC { runResumableC :: ErrorC (SomeError err) m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
-instance (Algebra sig m, Effect sig) => Algebra (Resumable err :+: sig) (ResumableC err m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (ResumableC err m) where
+  type Signature (ResumableC err m) = Resumable err :+: Signature m
   alg (L (Resumable err _)) = ResumableC (throwError (SomeError err))
   alg (R other)             = ResumableC (alg (R (handleCoercible other)))
   {-# INLINE alg #-}

--- a/src/Control/Algebra/Resumable/Resume.hs
+++ b/src/Control/Algebra/Resumable/Resume.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Resumable.Resume
 , runResumable
 , ResumableC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Resumable/Resume.hs
+++ b/src/Control/Algebra/Resumable/Resume.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, RankNTypes, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Resumable.Resume
 ( -- * Resumable effect
   module Control.Effect.Resumable
@@ -44,7 +44,8 @@ instance MonadTrans (ResumableC err) where
 
 newtype Handler err m = Handler { runHandler :: forall x . err x -> m x }
 
-instance Algebra sig m => Algebra (Resumable err :+: sig) (ResumableC err m) where
+instance Algebra m => Algebra (ResumableC err m) where
+  type Signature (ResumableC err m) = Resumable err :+: Signature m
   alg (L (Resumable err k)) = ResumableC (ReaderC (\ handler -> runHandler handler err)) >>= k
   alg (R other)             = ResumableC (alg (R (handleCoercible other)))
   {-# INLINE alg #-}

--- a/src/Control/Algebra/Resumable/Resume.hs
+++ b/src/Control/Algebra/Resumable/Resume.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Resumable.Resume
 , runResumable
 , ResumableC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/State/Lazy.hs
+++ b/src/Control/Algebra/State/Lazy.hs
@@ -8,8 +8,7 @@ module Control.Algebra.State.Lazy
 , execState
 , StateC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/State/Lazy.hs
+++ b/src/Control/Algebra/State/Lazy.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.State.Lazy
 ( -- * State effect
   module State
@@ -69,7 +69,8 @@ instance MonadTrans (StateC s) where
   lift m = StateC (\ s -> (,) s <$> m)
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (State s :+: sig) (StateC s m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (StateC s m) where
+  type Signature (StateC s m) = State s :+: Signature m
   alg (L (Get   k)) = StateC (\ s -> runState s (k s))
   alg (L (Put s k)) = StateC (\ _ -> runState s k)
   alg (R other)     = StateC (\ s -> alg (handle (s, ()) (uncurry runState) other))

--- a/src/Control/Algebra/State/Lazy.hs
+++ b/src/Control/Algebra/State/Lazy.hs
@@ -8,7 +8,7 @@ module Control.Algebra.State.Lazy
 , execState
 , StateC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/State/Strict.hs
+++ b/src/Control/Algebra/State/Strict.hs
@@ -8,8 +8,7 @@ module Control.Algebra.State.Strict
 , execState
 , StateC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/State/Strict.hs
+++ b/src/Control/Algebra/State/Strict.hs
@@ -8,7 +8,7 @@ module Control.Algebra.State.Strict
 , execState
 , StateC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/State/Strict.hs
+++ b/src/Control/Algebra/State/Strict.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveFunctor, ExplicitForAll, FlexibleContexts, FlexibleInstances, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.State.Strict
 ( -- * State effect
   module Control.Effect.State
@@ -90,7 +90,8 @@ instance MonadTrans (StateC s) where
   lift m = StateC (\ s -> (,) s <$> m)
   {-# INLINE lift #-}
 
-instance (Algebra sig m, Effect sig) => Algebra (State s :+: sig) (StateC s m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (StateC s m) where
+  type Signature (StateC s m) = State s :+: Signature m
   alg (L (Get   k)) = StateC (\ s -> runState s (k s))
   alg (L (Put s k)) = StateC (\ _ -> runState s k)
   alg (R other)     = StateC (\ s -> alg (handle (s, ()) (uncurry runState) other))

--- a/src/Control/Algebra/Trace/Ignoring.hs
+++ b/src/Control/Algebra/Trace/Ignoring.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Trace.Ignoring
 , runTrace
 , TraceC(..)
 -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Trace/Ignoring.hs
+++ b/src/Control/Algebra/Trace/Ignoring.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Trace.Ignoring
 , runTrace
 , TraceC(..)
 -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Trace/Ignoring.hs
+++ b/src/Control/Algebra/Trace/Ignoring.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Trace.Ignoring
 ( -- * Trace effect
   module Control.Effect.Trace
@@ -33,7 +33,8 @@ instance MonadTrans TraceC where
   lift = TraceC
   {-# INLINE lift #-}
 
-instance Algebra sig m => Algebra (Trace :+: sig) (TraceC m) where
+instance Algebra m => Algebra (TraceC m) where
+  type Signature (TraceC m) = Trace :+: Signature m
   alg (L trace) = traceCont trace
   alg (R other) = TraceC (alg (handleCoercible other))
   {-# INLINE alg #-}

--- a/src/Control/Algebra/Trace/Printing.hs
+++ b/src/Control/Algebra/Trace/Printing.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Trace.Printing
 , runTrace
 , TraceC(..)
 -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Trace/Printing.hs
+++ b/src/Control/Algebra/Trace/Printing.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Trace.Printing
 , runTrace
 , TraceC(..)
 -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Trace/Printing.hs
+++ b/src/Control/Algebra/Trace/Printing.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Trace.Printing
 ( -- * Trace effect
   module Control.Effect.Trace
@@ -32,7 +32,8 @@ instance MonadTrans TraceC where
   lift = TraceC
   {-# INLINE lift #-}
 
-instance (MonadIO m, Algebra sig m) => Algebra (Trace :+: sig) (TraceC m) where
+instance (MonadIO m, Algebra m) => Algebra (TraceC m) where
+  type Signature (TraceC m) = Trace :+: Signature m
   alg (L (Trace s k)) = liftIO (hPutStrLn stderr s) *> k
   alg (R other)       = TraceC (alg (handleCoercible other))
   {-# INLINE alg #-}

--- a/src/Control/Algebra/Trace/Returning.hs
+++ b/src/Control/Algebra/Trace/Returning.hs
@@ -6,8 +6,7 @@ module Control.Algebra.Trace.Returning
 , runTrace
 , TraceC(..)
 -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Trace/Returning.hs
+++ b/src/Control/Algebra/Trace/Returning.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Trace.Returning
 ( -- * Trace effect
   module Control.Effect.Trace
@@ -31,7 +31,8 @@ runTrace = fmap (first reverse) . runState [] . runTraceC
 newtype TraceC m a = TraceC { runTraceC :: StateC [String] m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
-instance (Algebra sig m, Effect sig) => Algebra (Trace :+: sig) (TraceC m) where
+instance (Algebra m, Effect (Signature m)) => Algebra (TraceC m) where
+  type Signature (TraceC m) = Trace :+: Signature m
   alg (L (Trace m k)) = TraceC (modify (m :)) *> k
   alg (R other)       = TraceC (alg (R (handleCoercible other)))
 

--- a/src/Control/Algebra/Trace/Returning.hs
+++ b/src/Control/Algebra/Trace/Returning.hs
@@ -6,7 +6,7 @@ module Control.Algebra.Trace.Returning
 , runTrace
 , TraceC(..)
 -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Writer/Strict.hs
+++ b/src/Control/Algebra/Writer/Strict.hs
@@ -7,8 +7,7 @@ module Control.Algebra.Writer.Strict
 , execWriter
 , WriterC(..)
   -- * Re-exports
-, Algebra
-, Member
+, Handles
 , run
 ) where
 

--- a/src/Control/Algebra/Writer/Strict.hs
+++ b/src/Control/Algebra/Writer/Strict.hs
@@ -7,7 +7,7 @@ module Control.Algebra.Writer.Strict
 , execWriter
 , WriterC(..)
   -- * Re-exports
-, Handles
+, Has
 , run
 ) where
 

--- a/src/Control/Algebra/Writer/Strict.hs
+++ b/src/Control/Algebra/Writer/Strict.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, ScopedTypeVariables, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, ScopedTypeVariables, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Algebra.Writer.Strict
 ( -- * Writer effect
   module Control.Effect.Writer
@@ -43,7 +43,8 @@ execWriter = fmap fst . runWriter
 newtype WriterC w m a = WriterC { runWriterC :: StateC w m a }
   deriving (Alternative, Applicative, Functor, Monad, Fail.MonadFail, MonadFix, MonadIO, MonadPlus, MonadTrans)
 
-instance (Monoid w, Algebra sig m, Effect sig) => Algebra (Writer w :+: sig) (WriterC w m) where
+instance (Monoid w, Algebra m, Effect (Signature m)) => Algebra (WriterC w m) where
+  type Signature (WriterC w m) = Writer w :+: Signature m
   alg (L (Tell w     k)) = WriterC $ do
     modify (`mappend` w)
     runWriterC k

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -2,7 +2,7 @@ module Control.Effect
 ( module X
 ) where
 
-import Control.Algebra          as X ((:+:), Algebra, Effect, HFunctor, Member)
+import Control.Algebra          as X (Effect, HFunctor, Handles)
 import Control.Effect.Choose    as X (Choose)
 import Control.Effect.Cull      as X (Cull)
 import Control.Effect.Cut       as X (Cut)

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -2,7 +2,7 @@ module Control.Effect
 ( module X
 ) where
 
-import Control.Algebra          as X (Effect, HFunctor, Handles)
+import Control.Algebra          as X (Effect, HFunctor, Has)
 import Control.Effect.Choose    as X (Choose)
 import Control.Effect.Cull      as X (Cull)
 import Control.Effect.Cut       as X (Cut)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, RankNTypes, UndecidableInstances #-}
 module Control.Effect.Choose
 ( -- * Choose effect
   Choose(..)
@@ -27,23 +27,23 @@ instance HFunctor Choose
 instance Effect   Choose
 
 -- | Nondeterministically choose between two computations.
-choose :: m `Handles` Choose => m a -> m a -> m a
+choose :: Has Choose m => m a -> m a -> m a
 choose a b = send (Choose (bool b a))
 
 -- | Select between 'Just' the result of an operation, and 'Nothing'.
-optional :: m `Handles` Choose => m a -> m (Maybe a)
+optional :: Has Choose m => m a -> m (Maybe a)
 optional a = choose (Just <$> a) (pure Nothing)
 
 -- | Zero or more.
-many :: m `Handles` Choose => m a -> m [a]
+many :: Has Choose m => m a -> m [a]
 many a = go where go = choose ((:) <$> a <*> go) (pure [])
 
 -- | One or more.
-some :: m `Handles` Choose => m a -> m [a]
+some :: Has Choose m => m a -> m [a]
 some a = (:) <$> a <*> many a
 
 -- | One or more, returning a 'NonEmpty' list of the results.
-some1 :: m `Handles` Choose => m a -> m (NonEmpty a)
+some1 :: Has Choose m => m a -> m (NonEmpty a)
 some1 a = (:|) <$> a <*> many a
 
 
@@ -58,15 +58,15 @@ some1 a = (:|) <$> a <*> many a
 --     guard (a^2 + b^2 == c^2)
 --     pure (a, b, c)
 -- @
-oneOf :: (Foldable t, m `Handles` Choose, m `Handles` Empty) => t a -> m a
+oneOf :: (Foldable t, Has Choose m, Has Empty m) => t a -> m a
 oneOf = getChoosing #. foldMap (Choosing #. pure)
 
 newtype Choosing m a = Choosing { getChoosing :: m a }
 
-instance m `Handles` Choose => Semigroup (Choosing m a) where
+instance Has Choose m => Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (choose m1 m2)
 
-instance (m `Handles` Choose, m `Handles` Empty) => Monoid (Choosing m a) where
+instance (Has Choose m, Has Empty m) => Monoid (Choosing m a) where
   mempty = Choosing (send Empty)
 
 

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -2,7 +2,7 @@
 module Control.Effect.Choose
 ( -- * Choose effect
   Choose(..)
-, choose
+, (<|>)
 , optional
 , many
 , some
@@ -27,16 +27,18 @@ instance HFunctor Choose
 instance Effect   Choose
 
 -- | Nondeterministically choose between two computations.
-choose :: Has Choose m => m a -> m a -> m a
-choose a b = send (Choose (bool b a))
+(<|>) :: Has Choose m => m a -> m a -> m a
+(<|>) a b = send (Choose (bool b a))
+
+infixl 3 <|>
 
 -- | Select between 'Just' the result of an operation, and 'Nothing'.
 optional :: Has Choose m => m a -> m (Maybe a)
-optional a = choose (Just <$> a) (pure Nothing)
+optional a = Just <$> a <|> pure Nothing
 
 -- | Zero or more.
 many :: Has Choose m => m a -> m [a]
-many a = go where go = choose ((:) <$> a <*> go) (pure [])
+many a = go where go = (:) <$> a <*> go <|> pure []
 
 -- | One or more.
 some :: Has Choose m => m a -> m [a]
@@ -64,7 +66,7 @@ oneOf = getChoosing #. foldMap (Choosing #. pure)
 newtype Choosing m a = Choosing { getChoosing :: m a }
 
 instance Has Choose m => Semigroup (Choosing m a) where
-  Choosing m1 <> Choosing m2 = Choosing (choose m1 m2)
+  Choosing m1 <> Choosing m2 = Choosing (m1 <|> m2)
 
 instance (Has Choose m, Has Empty m) => Monoid (Choosing m a) where
   mempty = Choosing (send Empty)

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -27,23 +27,23 @@ instance HFunctor Choose
 instance Effect   Choose
 
 -- | Nondeterministically choose between two computations.
-choose :: (Algebra sig m, Member Choose sig) => m a -> m a -> m a
+choose :: (Algebra m, Member Choose (Signature m)) => m a -> m a -> m a
 choose a b = send (Choose (bool b a))
 
 -- | Select between 'Just' the result of an operation, and 'Nothing'.
-optional :: (Algebra sig m, Member Choose sig) => m a -> m (Maybe a)
+optional :: (Algebra m, Member Choose (Signature m)) => m a -> m (Maybe a)
 optional a = choose (Just <$> a) (pure Nothing)
 
 -- | Zero or more.
-many :: (Algebra sig m, Member Choose sig) => m a -> m [a]
+many :: (Algebra m, Member Choose (Signature m)) => m a -> m [a]
 many a = go where go = choose ((:) <$> a <*> go) (pure [])
 
 -- | One or more.
-some :: (Algebra sig m, Member Choose sig) => m a -> m [a]
+some :: (Algebra m, Member Choose (Signature m)) => m a -> m [a]
 some a = (:) <$> a <*> many a
 
 -- | One or more, returning a 'NonEmpty' list of the results.
-some1 :: (Algebra sig m, Member Choose sig) => m a -> m (NonEmpty a)
+some1 :: (Algebra m, Member Choose (Signature m)) => m a -> m (NonEmpty a)
 some1 a = (:|) <$> a <*> many a
 
 
@@ -58,15 +58,15 @@ some1 a = (:|) <$> a <*> many a
 --     guard (a^2 + b^2 == c^2)
 --     pure (a, b, c)
 -- @
-oneOf :: (Foldable t, Algebra sig m, Member Choose sig, Member Empty sig) => t a -> m a
+oneOf :: (Foldable t, Algebra m, Member Choose (Signature m), Member Empty (Signature m)) => t a -> m a
 oneOf = getChoosing #. foldMap (Choosing #. pure)
 
 newtype Choosing m a = Choosing { getChoosing :: m a }
 
-instance (Algebra sig m, Member Choose sig) => Semigroup (Choosing m a) where
+instance (Algebra m, Member Choose (Signature m)) => Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (choose m1 m2)
 
-instance (Algebra sig m, Member Choose sig, Member Empty sig) => Monoid (Choosing m a) where
+instance (Algebra m, Member Choose (Signature m), Member Empty (Signature m)) => Monoid (Choosing m a) where
   mempty = Choosing (send Empty)
 
 

--- a/src/Control/Effect/Choose.hs
+++ b/src/Control/Effect/Choose.hs
@@ -27,23 +27,23 @@ instance HFunctor Choose
 instance Effect   Choose
 
 -- | Nondeterministically choose between two computations.
-choose :: (Algebra m, Member Choose (Signature m)) => m a -> m a -> m a
+choose :: m `Handles` Choose => m a -> m a -> m a
 choose a b = send (Choose (bool b a))
 
 -- | Select between 'Just' the result of an operation, and 'Nothing'.
-optional :: (Algebra m, Member Choose (Signature m)) => m a -> m (Maybe a)
+optional :: m `Handles` Choose => m a -> m (Maybe a)
 optional a = choose (Just <$> a) (pure Nothing)
 
 -- | Zero or more.
-many :: (Algebra m, Member Choose (Signature m)) => m a -> m [a]
+many :: m `Handles` Choose => m a -> m [a]
 many a = go where go = choose ((:) <$> a <*> go) (pure [])
 
 -- | One or more.
-some :: (Algebra m, Member Choose (Signature m)) => m a -> m [a]
+some :: m `Handles` Choose => m a -> m [a]
 some a = (:) <$> a <*> many a
 
 -- | One or more, returning a 'NonEmpty' list of the results.
-some1 :: (Algebra m, Member Choose (Signature m)) => m a -> m (NonEmpty a)
+some1 :: m `Handles` Choose => m a -> m (NonEmpty a)
 some1 a = (:|) <$> a <*> many a
 
 
@@ -58,15 +58,15 @@ some1 a = (:|) <$> a <*> many a
 --     guard (a^2 + b^2 == c^2)
 --     pure (a, b, c)
 -- @
-oneOf :: (Foldable t, Algebra m, Member Choose (Signature m), Member Empty (Signature m)) => t a -> m a
+oneOf :: (Foldable t, m `Handles` Choose, m `Handles` Empty) => t a -> m a
 oneOf = getChoosing #. foldMap (Choosing #. pure)
 
 newtype Choosing m a = Choosing { getChoosing :: m a }
 
-instance (Algebra m, Member Choose (Signature m)) => Semigroup (Choosing m a) where
+instance m `Handles` Choose => Semigroup (Choosing m a) where
   Choosing m1 <> Choosing m2 = Choosing (choose m1 m2)
 
-instance (Algebra m, Member Choose (Signature m), Member Empty (Signature m)) => Monoid (Choosing m a) where
+instance (m `Handles` Choose, m `Handles` Empty) => Monoid (Choosing m a) where
   mempty = Choosing (send Empty)
 
 

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -30,7 +30,7 @@ instance Effect Cull where
 --   prop> run (runNonDet (runCull (cull (empty  <|> pure a)))) === [a]
 --   prop> run (runNonDet (runCull (cull (pure a <|> pure b) <|> pure c))) === [a, c]
 --   prop> run (runNonDet (runCull (cull (asum (map pure (repeat a)))))) === [a]
-cull :: (Algebra sig m, Member Cull sig) => m a -> m a
+cull :: (Algebra m, Member Cull (Signature m)) => m a -> m a
 cull m = send (Cull m pure)
 
 

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -30,7 +30,7 @@ instance Effect Cull where
 --   prop> run (runNonDet (runCull (cull (empty  <|> pure a)))) === [a]
 --   prop> run (runNonDet (runCull (cull (pure a <|> pure b) <|> pure c))) === [a, c]
 --   prop> run (runNonDet (runCull (cull (asum (map pure (repeat a)))))) === [a]
-cull :: m `Handles` Cull => m a -> m a
+cull :: Has Cull m => m a -> m a
 cull m = send (Cull m pure)
 
 

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
 module Control.Effect.Cull
 ( -- * Cull effect
   Cull(..)

--- a/src/Control/Effect/Cull.hs
+++ b/src/Control/Effect/Cull.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
 module Control.Effect.Cull
 ( -- * Cull effect
   Cull(..)
@@ -30,7 +30,7 @@ instance Effect Cull where
 --   prop> run (runNonDet (runCull (cull (empty  <|> pure a)))) === [a]
 --   prop> run (runNonDet (runCull (cull (pure a <|> pure b) <|> pure c))) === [a, c]
 --   prop> run (runNonDet (runCull (cull (asum (map pure (repeat a)))))) === [a]
-cull :: (Algebra m, Member Cull (Signature m)) => m a -> m a
+cull :: m `Handles` Cull => m a -> m a
 cull m = send (Cull m pure)
 
 

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -33,14 +33,14 @@ instance Effect Cut where
 --
 --   prop> run (runNonDet (runCut (cutfail <|> pure a))) === []
 --   prop> run (runNonDet (runCut (pure a <|> cutfail))) === [a]
-cutfail :: m `Handles` Cut => m a
+cutfail :: Has Cut m => m a
 cutfail = send Cutfail
 {-# INLINE cutfail #-}
 
 -- | Delimit the effect of 'cutfail's, allowing backtracking to resume.
 --
 --   prop> run (runNonDet (runCut (call (cutfail <|> pure a) <|> pure b))) === [b]
-call :: m `Handles` Cut => m a -> m a
+call :: Has Cut m => m a -> m a
 call m = send (Call m pure)
 {-# INLINE call #-}
 
@@ -49,7 +49,7 @@ call m = send (Call m pure)
 --   prop> run (runNonDet (runCut (pure a <|> cut *> pure b))) === [a, b]
 --   prop> run (runNonDet (runCut (cut *> pure a <|> pure b))) === [a]
 --   prop> run (runNonDet (runCut (cut *> empty <|> pure a))) === []
-cut :: (Alternative m, m `Handles` Cut) => m ()
+cut :: (Alternative m, Has Cut m) => m ()
 cut = pure () <|> cutfail
 {-# INLINE cut #-}
 

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, GeneralizedNewtypeDeriving, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, GeneralizedNewtypeDeriving, StandaloneDeriving, TypeOperators #-}
 module Control.Effect.Cut
 ( -- * Cut effect
   Cut(..)
@@ -33,14 +33,14 @@ instance Effect Cut where
 --
 --   prop> run (runNonDet (runCut (cutfail <|> pure a))) === []
 --   prop> run (runNonDet (runCut (pure a <|> cutfail))) === [a]
-cutfail :: (Algebra m, Member Cut (Signature m)) => m a
+cutfail :: m `Handles` Cut => m a
 cutfail = send Cutfail
 {-# INLINE cutfail #-}
 
 -- | Delimit the effect of 'cutfail's, allowing backtracking to resume.
 --
 --   prop> run (runNonDet (runCut (call (cutfail <|> pure a) <|> pure b))) === [b]
-call :: (Algebra m, Member Cut (Signature m)) => m a -> m a
+call :: m `Handles` Cut => m a -> m a
 call m = send (Call m pure)
 {-# INLINE call #-}
 
@@ -49,7 +49,7 @@ call m = send (Call m pure)
 --   prop> run (runNonDet (runCut (pure a <|> cut *> pure b))) === [a, b]
 --   prop> run (runNonDet (runCut (cut *> pure a <|> pure b))) === [a]
 --   prop> run (runNonDet (runCut (cut *> empty <|> pure a))) === []
-cut :: (Alternative m, Algebra m, Member Cut (Signature m)) => m ()
+cut :: (Alternative m, m `Handles` Cut) => m ()
 cut = pure () <|> cutfail
 {-# INLINE cut #-}
 

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, GeneralizedNewtypeDeriving, StandaloneDeriving, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, GeneralizedNewtypeDeriving, StandaloneDeriving #-}
 module Control.Effect.Cut
 ( -- * Cut effect
   Cut(..)

--- a/src/Control/Effect/Cut.hs
+++ b/src/Control/Effect/Cut.hs
@@ -33,14 +33,14 @@ instance Effect Cut where
 --
 --   prop> run (runNonDet (runCut (cutfail <|> pure a))) === []
 --   prop> run (runNonDet (runCut (pure a <|> cutfail))) === [a]
-cutfail :: (Algebra sig m, Member Cut sig) => m a
+cutfail :: (Algebra m, Member Cut (Signature m)) => m a
 cutfail = send Cutfail
 {-# INLINE cutfail #-}
 
 -- | Delimit the effect of 'cutfail's, allowing backtracking to resume.
 --
 --   prop> run (runNonDet (runCut (call (cutfail <|> pure a) <|> pure b))) === [b]
-call :: (Algebra sig m, Member Cut sig) => m a -> m a
+call :: (Algebra m, Member Cut (Signature m)) => m a -> m a
 call m = send (Call m pure)
 {-# INLINE call #-}
 
@@ -49,7 +49,7 @@ call m = send (Call m pure)
 --   prop> run (runNonDet (runCut (pure a <|> cut *> pure b))) === [a, b]
 --   prop> run (runNonDet (runCut (cut *> pure a <|> pure b))) === [a]
 --   prop> run (runNonDet (runCut (cut *> empty <|> pure a))) === []
-cut :: (Alternative m, Algebra sig m, Member Cut sig) => m ()
+cut :: (Alternative m, Algebra m, Member Cut (Signature m)) => m ()
 cut = pure () <|> cutfail
 {-# INLINE cut #-}
 

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -20,5 +20,5 @@ instance Effect   Empty
 -- | Abort the computation.
 --
 --   prop> run (runEmpty abort) === Nothing
-abort :: (Algebra sig m, Member Empty sig) => m a
+abort :: (Algebra m, Member Empty (Signature m)) => m a
 abort = send Empty

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -2,7 +2,7 @@
 module Control.Effect.Empty
 ( -- * Empty effect
   Empty(..)
-, abort
+, empty
 ) where
 
 import Control.Algebra
@@ -19,6 +19,6 @@ instance Effect   Empty
 
 -- | Abort the computation.
 --
---   prop> run (runEmpty abort) === Nothing
-abort :: Has Empty m => m a
-abort = send Empty
+--   prop> run (runEmpty empty) === Nothing
+empty :: Has Empty m => m a
+empty = send Empty

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, KindSignatures, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, KindSignatures #-}
 module Control.Effect.Empty
 ( -- * Empty effect
   Empty(..)

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, KindSignatures #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, KindSignatures, TypeOperators #-}
 module Control.Effect.Empty
 ( -- * Empty effect
   Empty(..)
@@ -20,5 +20,5 @@ instance Effect   Empty
 -- | Abort the computation.
 --
 --   prop> run (runEmpty abort) === Nothing
-abort :: (Algebra m, Member Empty (Signature m)) => m a
+abort :: m `Handles` Empty => m a
 abort = send Empty

--- a/src/Control/Effect/Empty.hs
+++ b/src/Control/Effect/Empty.hs
@@ -20,5 +20,5 @@ instance Effect   Empty
 -- | Abort the computation.
 --
 --   prop> run (runEmpty abort) === Nothing
-abort :: m `Handles` Empty => m a
+abort :: Has Empty m => m a
 abort = send Empty

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -25,7 +25,7 @@ instance Effect (Error exc) where
 -- | Throw an error, escaping the current computation up to the nearest 'catchError' (if any).
 --
 --   prop> run (runError (throwError a)) === Left @Int @Int a
-throwError :: m `Handles` Error exc => exc -> m a
+throwError :: Has (Error exc) m => exc -> m a
 throwError = send . Throw
 
 -- | Run a computation which can throw errors with a handler to run on error.
@@ -39,7 +39,7 @@ throwError = send . Throw
 --   prop> run (runError (pure a `catchError` pure)) === Right a
 --   prop> run (runError (throwError a `catchError` pure)) === Right @Int @Int a
 --   prop> run (runError (throwError a `catchError` (throwError @Int))) === Left @Int @Int a
-catchError :: m `Handles` Error exc => m a -> (exc -> m a) -> m a
+catchError :: Has (Error exc) m => m a -> (exc -> m a) -> m a
 catchError m h = send (Catch m h pure)
 
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
 module Control.Effect.Error
 ( -- * Error effect
   Error(..)
@@ -25,7 +25,7 @@ instance Effect (Error exc) where
 -- | Throw an error, escaping the current computation up to the nearest 'catchError' (if any).
 --
 --   prop> run (runError (throwError a)) === Left @Int @Int a
-throwError :: (Member (Error exc) (Signature m), Algebra m) => exc -> m a
+throwError :: m `Handles` Error exc => exc -> m a
 throwError = send . Throw
 
 -- | Run a computation which can throw errors with a handler to run on error.
@@ -39,7 +39,7 @@ throwError = send . Throw
 --   prop> run (runError (pure a `catchError` pure)) === Right a
 --   prop> run (runError (throwError a `catchError` pure)) === Right @Int @Int a
 --   prop> run (runError (throwError a `catchError` (throwError @Int))) === Left @Int @Int a
-catchError :: (Member (Error exc) (Signature m), Algebra m) => m a -> (exc -> m a) -> m a
+catchError :: m `Handles` Error exc => m a -> (exc -> m a) -> m a
 catchError m h = send (Catch m h pure)
 
 

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
 module Control.Effect.Error
 ( -- * Error effect
   Error(..)

--- a/src/Control/Effect/Error.hs
+++ b/src/Control/Effect/Error.hs
@@ -25,7 +25,7 @@ instance Effect (Error exc) where
 -- | Throw an error, escaping the current computation up to the nearest 'catchError' (if any).
 --
 --   prop> run (runError (throwError a)) === Left @Int @Int a
-throwError :: (Member (Error exc) sig, Algebra sig m) => exc -> m a
+throwError :: (Member (Error exc) (Signature m), Algebra m) => exc -> m a
 throwError = send . Throw
 
 -- | Run a computation which can throw errors with a handler to run on error.
@@ -39,7 +39,7 @@ throwError = send . Throw
 --   prop> run (runError (pure a `catchError` pure)) === Right a
 --   prop> run (runError (throwError a `catchError` pure)) === Right @Int @Int a
 --   prop> run (runError (throwError a `catchError` (throwError @Int))) === Left @Int @Int a
-catchError :: (Member (Error exc) sig, Algebra sig m) => m a -> (exc -> m a) -> m a
+catchError :: (Member (Error exc) (Signature m), Algebra m) => m a -> (exc -> m a) -> m a
 catchError m h = send (Catch m h pure)
 
 

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -25,11 +25,11 @@ instance Effect Fresh where
 -- | Produce a fresh (i.e. unique) 'Int'.
 --
 --   prop> run (runFresh (replicateM n fresh)) === nub (run (runFresh (replicateM n fresh)))
-fresh :: (Member Fresh sig, Algebra sig m) => m Int
+fresh :: (Member Fresh (Signature m), Algebra m) => m Int
 fresh = send (Fresh pure)
 
 -- | Reset the fresh counter after running a computation.
 --
 --   prop> run (runFresh (resetFresh (replicateM m fresh) *> replicateM n fresh)) === run (runFresh (replicateM n fresh))
-resetFresh :: (Member Fresh sig, Algebra sig m) => m a -> m a
+resetFresh :: (Member Fresh (Signature m), Algebra m) => m a -> m a
 resetFresh m = send (Reset m pure)

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -25,11 +25,11 @@ instance Effect Fresh where
 -- | Produce a fresh (i.e. unique) 'Int'.
 --
 --   prop> run (runFresh (replicateM n fresh)) === nub (run (runFresh (replicateM n fresh)))
-fresh :: m `Handles` Fresh => m Int
+fresh :: Has Fresh m => m Int
 fresh = send (Fresh pure)
 
 -- | Reset the fresh counter after running a computation.
 --
 --   prop> run (runFresh (resetFresh (replicateM m fresh) *> replicateM n fresh)) === run (runFresh (replicateM n fresh))
-resetFresh :: m `Handles` Fresh => m a -> m a
+resetFresh :: Has Fresh m => m a -> m a
 resetFresh m = send (Reset m pure)

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
 module Control.Effect.Fresh
 ( -- * Fresh effect
   Fresh(..)

--- a/src/Control/Effect/Fresh.hs
+++ b/src/Control/Effect/Fresh.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
 module Control.Effect.Fresh
 ( -- * Fresh effect
   Fresh(..)
@@ -25,11 +25,11 @@ instance Effect Fresh where
 -- | Produce a fresh (i.e. unique) 'Int'.
 --
 --   prop> run (runFresh (replicateM n fresh)) === nub (run (runFresh (replicateM n fresh)))
-fresh :: (Member Fresh (Signature m), Algebra m) => m Int
+fresh :: m `Handles` Fresh => m Int
 fresh = send (Fresh pure)
 
 -- | Reset the fresh counter after running a computation.
 --
 --   prop> run (runFresh (resetFresh (replicateM m fresh) *> replicateM n fresh)) === run (runFresh (replicateM n fresh))
-resetFresh :: (Member Fresh (Signature m), Algebra m) => m a -> m a
+resetFresh :: m `Handles` Fresh => m a -> m a
 resetFresh m = send (Reset m pure)

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -17,5 +17,5 @@ instance Functor m => Effect   (Lift m)
 -- | Given a @Lift n@ constraint in a signature carried by @m@, 'sendM'
 -- promotes arbitrary actions of type @n a@ to @m a@. It is spiritually
 -- similar to @lift@ from the @MonadTrans@ typeclass.
-sendM :: (m `Handles` Lift n, Functor n) => n a -> m a
+sendM :: (Has (Lift n) m, Functor n) => n a -> m a
 sendM = send . Lift . fmap pure

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts #-}
 module Control.Effect.Lift
 ( -- * Lift effect
   Lift(..)

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -17,5 +17,5 @@ instance Functor m => Effect   (Lift m)
 -- | Given a @Lift n@ constraint in a signature carried by @m@, 'sendM'
 -- promotes arbitrary actions of type @n a@ to @m a@. It is spiritually
 -- similar to @lift@ from the @MonadTrans@ typeclass.
-sendM :: (Member (Lift n) sig, Algebra sig m, Functor n) => n a -> m a
+sendM :: (Member (Lift n) (Signature m), Algebra m, Functor n) => n a -> m a
 sendM = send . Lift . fmap pure

--- a/src/Control/Effect/Lift.hs
+++ b/src/Control/Effect/Lift.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, TypeOperators #-}
 module Control.Effect.Lift
 ( -- * Lift effect
   Lift(..)
@@ -17,5 +17,5 @@ instance Functor m => Effect   (Lift m)
 -- | Given a @Lift n@ constraint in a signature carried by @m@, 'sendM'
 -- promotes arbitrary actions of type @n a@ to @m a@. It is spiritually
 -- similar to @lift@ from the @MonadTrans@ typeclass.
-sendM :: (Member (Lift n) (Signature m), Algebra m, Functor n) => n a -> m a
+sendM :: (m `Handles` Lift n, Functor n) => n a -> m a
 sendM = send . Lift . fmap pure

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -4,9 +4,11 @@ module Control.Effect.NonDet
   module Control.Effect.Choose
 , module Control.Effect.Empty
 , NonDet
+, Alternative(..)
 ) where
 
-import Control.Effect.Choose
+import Control.Applicative (Alternative(..))
+import Control.Effect.Choose hiding (many, some)
 import Control.Effect.Empty
 import Control.Effect.Sum
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -8,7 +8,7 @@ module Control.Effect.NonDet
 ) where
 
 import Control.Applicative (Alternative(..))
-import Control.Effect.Choose hiding (many, some)
+import Control.Effect.Choose hiding ((<|>), many, some)
 import Control.Effect.Empty hiding (empty)
 import Control.Effect.Sum
 

--- a/src/Control/Effect/NonDet.hs
+++ b/src/Control/Effect/NonDet.hs
@@ -9,7 +9,7 @@ module Control.Effect.NonDet
 
 import Control.Applicative (Alternative(..))
 import Control.Effect.Choose hiding (many, some)
-import Control.Effect.Empty
+import Control.Effect.Empty hiding (empty)
 import Control.Effect.Sum
 
 type NonDet = Empty :+: Choose

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
 module Control.Effect.Reader
 ( -- * Reader effect
   Reader(..)

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
 module Control.Effect.Reader
 ( -- * Reader effect
   Reader(..)
@@ -26,20 +26,20 @@ instance Effect (Reader r) where
 -- | Retrieve the environment value.
 --
 --   prop> run (runReader a ask) === a
-ask :: (Member (Reader r) (Signature m), Algebra m) => m r
+ask :: m `Handles` Reader r => m r
 ask = send (Ask pure)
 
 -- | Project a function out of the current environment value.
 --
 --   prop> snd (run (runReader a (asks (applyFun f)))) === applyFun f a
-asks :: (Member (Reader r) (Signature m), Algebra m) => (r -> a) -> m a
+asks :: m `Handles` Reader r => (r -> a) -> m a
 asks f = send (Ask (pure . f))
 
 -- | Run a computation with an environment value locally modified by the passed function.
 --
 --   prop> run (runReader a (local (applyFun f) ask)) === applyFun f a
 --   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) === (a, applyFun f a, a)
-local :: (Member (Reader r) (Signature m), Algebra m) => (r -> r) -> m a -> m a
+local :: m `Handles` Reader r => (r -> r) -> m a -> m a
 local f m = send (Local f m pure)
 
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -26,20 +26,20 @@ instance Effect (Reader r) where
 -- | Retrieve the environment value.
 --
 --   prop> run (runReader a ask) === a
-ask :: m `Handles` Reader r => m r
+ask :: Has (Reader r) m => m r
 ask = send (Ask pure)
 
 -- | Project a function out of the current environment value.
 --
 --   prop> snd (run (runReader a (asks (applyFun f)))) === applyFun f a
-asks :: m `Handles` Reader r => (r -> a) -> m a
+asks :: Has (Reader r) m => (r -> a) -> m a
 asks f = send (Ask (pure . f))
 
 -- | Run a computation with an environment value locally modified by the passed function.
 --
 --   prop> run (runReader a (local (applyFun f) ask)) === applyFun f a
 --   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) === (a, applyFun f a, a)
-local :: m `Handles` Reader r => (r -> r) -> m a -> m a
+local :: Has (Reader r) m => (r -> r) -> m a -> m a
 local f m = send (Local f m pure)
 
 

--- a/src/Control/Effect/Reader.hs
+++ b/src/Control/Effect/Reader.hs
@@ -26,20 +26,20 @@ instance Effect (Reader r) where
 -- | Retrieve the environment value.
 --
 --   prop> run (runReader a ask) === a
-ask :: (Member (Reader r) sig, Algebra sig m) => m r
+ask :: (Member (Reader r) (Signature m), Algebra m) => m r
 ask = send (Ask pure)
 
 -- | Project a function out of the current environment value.
 --
 --   prop> snd (run (runReader a (asks (applyFun f)))) === applyFun f a
-asks :: (Member (Reader r) sig, Algebra sig m) => (r -> a) -> m a
+asks :: (Member (Reader r) (Signature m), Algebra m) => (r -> a) -> m a
 asks f = send (Ask (pure . f))
 
 -- | Run a computation with an environment value locally modified by the passed function.
 --
 --   prop> run (runReader a (local (applyFun f) ask)) === applyFun f a
 --   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) === (a, applyFun f a, a)
-local :: (Member (Reader r) sig, Algebra sig m) => (r -> r) -> m a -> m a
+local :: (Member (Reader r) (Signature m), Algebra m) => (r -> r) -> m a -> m a
 local f m = send (Local f m pure)
 
 

--- a/src/Control/Effect/Reader/Named.hs
+++ b/src/Control/Effect/Reader/Named.hs
@@ -14,18 +14,18 @@ import Control.Effect.Reader (Reader(..))
 -- | Retrieve the environment value.
 --
 --   prop> run (runReader a ask) === a
-ask :: forall name r m sig . (NamedMember name (Reader r) sig, Algebra sig m) => m r
+ask :: forall name r m . (NamedMember name (Reader r) (Signature m), Algebra m) => m r
 ask = sendNamed @name (Ask pure)
 
 -- | Project a function out of the current environment value.
 --
 --   prop> snd (run (runReader a (asks (applyFun f)))) === applyFun f a
-asks :: forall name r m a sig . (NamedMember name (Reader r) sig, Algebra sig m) => (r -> a) -> m a
+asks :: forall name r m a . (NamedMember name (Reader r) (Signature m), Algebra m) => (r -> a) -> m a
 asks f = sendNamed @name (Ask (pure . f))
 
 -- | Run a computation with an environment value locally modified by the passed function.
 --
 --   prop> run (runReader a (local (applyFun f) ask)) === applyFun f a
 --   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) === (a, applyFun f a, a)
-local :: forall name r m a sig . (NamedMember name (Reader r) sig, Algebra sig m) => (r -> r) -> m a -> m a
+local :: forall name r m a . (NamedMember name (Reader r) (Signature m), Algebra m) => (r -> r) -> m a -> m a
 local f m = sendNamed @name (Local f m pure)

--- a/src/Control/Effect/Reader/Named.hs
+++ b/src/Control/Effect/Reader/Named.hs
@@ -7,25 +7,24 @@ module Control.Effect.Reader.Named
 , local
 ) where
 
-import Control.Algebra
 import Control.Effect.Sum.Named
 import Control.Effect.Reader (Reader(..))
 
 -- | Retrieve the environment value.
 --
 --   prop> run (runReader a ask) === a
-ask :: forall name r m . (NamedMember name (Reader r) (Signature m), Algebra m) => m r
+ask :: forall name r m . HasNamed name (Reader r) m => m r
 ask = sendNamed @name (Ask pure)
 
 -- | Project a function out of the current environment value.
 --
 --   prop> snd (run (runReader a (asks (applyFun f)))) === applyFun f a
-asks :: forall name r m a . (NamedMember name (Reader r) (Signature m), Algebra m) => (r -> a) -> m a
+asks :: forall name r m a . HasNamed name (Reader r) m => (r -> a) -> m a
 asks f = sendNamed @name (Ask (pure . f))
 
 -- | Run a computation with an environment value locally modified by the passed function.
 --
 --   prop> run (runReader a (local (applyFun f) ask)) === applyFun f a
 --   prop> run (runReader a ((,,) <$> ask <*> local (applyFun f) ask <*> ask)) === (a, applyFun f a, a)
-local :: forall name r m a . (NamedMember name (Reader r) (Signature m), Algebra m) => (r -> r) -> m a -> m a
+local :: forall name r m a . HasNamed name (Reader r) m => (r -> r) -> m a -> m a
 local f m = sendNamed @name (Local f m pure)

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -34,7 +34,7 @@ instance Effect Resource where
 -- if @op@ throws an exception.
 --
 -- 'bracket' is safe in the presence of asynchronous exceptions.
-bracket :: (Member Resource sig, Algebra sig m)
+bracket :: (Member Resource (Signature m), Algebra m)
         => m resource           -- ^ computation to run first ("acquire resource")
         -> (resource -> m any)  -- ^ computation to run last ("release resource")
         -> (resource -> m a)    -- ^ computation to run in-between
@@ -43,7 +43,7 @@ bracket acquire release use = send (Resource acquire release use pure)
 
 -- | Like 'bracket', but only performs the final action if there was an
 -- exception raised by the in-between computation.
-bracketOnError :: (Member Resource sig, Algebra sig m)
+bracketOnError :: (Member Resource (Signature m), Algebra m)
                => m resource           -- ^ computation to run first ("acquire resource")
                -> (resource -> m any)  -- ^ computation to run last ("release resource")
                -> (resource -> m a)    -- ^ computation to run in-between
@@ -51,14 +51,14 @@ bracketOnError :: (Member Resource sig, Algebra sig m)
 bracketOnError acquire release use = send (OnError acquire release use pure)
 
 -- | Like 'bracket', but for the simple case of one computation to run afterward.
-finally :: (Member Resource sig, Algebra sig m)
+finally :: (Member Resource (Signature m), Algebra m)
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward (even if an exception was raised)
         -> m a
 finally act end = bracket (pure ()) (const end) (const act)
 
 -- | Like 'bracketOnError', but for the simple case of one computation to run afterward.
-onException :: (Member Resource sig, Algebra sig m)
+onException :: (Member Resource (Signature m), Algebra m)
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward if an exception was raised
         -> m a

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
 module Control.Effect.Resource
 ( -- * Resource effect
   Resource(..)
@@ -34,7 +34,7 @@ instance Effect Resource where
 -- if @op@ throws an exception.
 --
 -- 'bracket' is safe in the presence of asynchronous exceptions.
-bracket :: (Member Resource (Signature m), Algebra m)
+bracket :: m `Handles` Resource
         => m resource           -- ^ computation to run first ("acquire resource")
         -> (resource -> m any)  -- ^ computation to run last ("release resource")
         -> (resource -> m a)    -- ^ computation to run in-between
@@ -43,7 +43,7 @@ bracket acquire release use = send (Resource acquire release use pure)
 
 -- | Like 'bracket', but only performs the final action if there was an
 -- exception raised by the in-between computation.
-bracketOnError :: (Member Resource (Signature m), Algebra m)
+bracketOnError :: m `Handles` Resource
                => m resource           -- ^ computation to run first ("acquire resource")
                -> (resource -> m any)  -- ^ computation to run last ("release resource")
                -> (resource -> m a)    -- ^ computation to run in-between
@@ -51,14 +51,14 @@ bracketOnError :: (Member Resource (Signature m), Algebra m)
 bracketOnError acquire release use = send (OnError acquire release use pure)
 
 -- | Like 'bracket', but for the simple case of one computation to run afterward.
-finally :: (Member Resource (Signature m), Algebra m)
+finally :: m `Handles` Resource
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward (even if an exception was raised)
         -> m a
 finally act end = bracket (pure ()) (const end) (const act)
 
 -- | Like 'bracketOnError', but for the simple case of one computation to run afterward.
-onException :: (Member Resource (Signature m), Algebra m)
+onException :: m `Handles` Resource
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward if an exception was raised
         -> m a

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -34,7 +34,7 @@ instance Effect Resource where
 -- if @op@ throws an exception.
 --
 -- 'bracket' is safe in the presence of asynchronous exceptions.
-bracket :: m `Handles` Resource
+bracket :: Has Resource m
         => m resource           -- ^ computation to run first ("acquire resource")
         -> (resource -> m any)  -- ^ computation to run last ("release resource")
         -> (resource -> m a)    -- ^ computation to run in-between
@@ -43,7 +43,7 @@ bracket acquire release use = send (Resource acquire release use pure)
 
 -- | Like 'bracket', but only performs the final action if there was an
 -- exception raised by the in-between computation.
-bracketOnError :: m `Handles` Resource
+bracketOnError :: Has Resource m
                => m resource           -- ^ computation to run first ("acquire resource")
                -> (resource -> m any)  -- ^ computation to run last ("release resource")
                -> (resource -> m a)    -- ^ computation to run in-between
@@ -51,14 +51,14 @@ bracketOnError :: m `Handles` Resource
 bracketOnError acquire release use = send (OnError acquire release use pure)
 
 -- | Like 'bracket', but for the simple case of one computation to run afterward.
-finally :: m `Handles` Resource
+finally :: Has Resource m
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward (even if an exception was raised)
         -> m a
 finally act end = bracket (pure ()) (const end) (const act)
 
 -- | Like 'bracketOnError', but for the simple case of one computation to run afterward.
-onException :: m `Handles` Resource
+onException :: Has Resource m
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward if an exception was raised
         -> m a

--- a/src/Control/Effect/Resource.hs
+++ b/src/Control/Effect/Resource.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
 module Control.Effect.Resource
 ( -- * Resource effect
   Resource(..)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -22,7 +22,7 @@ instance Effect (Resumable err) where
 -- | Throw an error which can be resumed with a value of its result type.
 --
 --   prop> run (runResumable (throwResumable (Identity a))) === Left (SomeError (Identity a))
-throwResumable :: m `Handles` Resumable err => err a -> m a
+throwResumable :: Has (Resumable err) m => err a -> m a
 throwResumable err = send (Resumable err pure)
 
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -22,7 +22,7 @@ instance Effect (Resumable err) where
 -- | Throw an error which can be resumed with a value of its result type.
 --
 --   prop> run (runResumable (throwResumable (Identity a))) === Left (SomeError (Identity a))
-throwResumable :: (Member (Resumable err) sig, Algebra sig m) => err a -> m a
+throwResumable :: (Member (Resumable err) (Signature m), Algebra m) => err a -> m a
 throwResumable err = send (Resumable err pure)
 
 

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
 module Control.Effect.Resumable
 ( -- * Resumable effect
   Resumable(..)

--- a/src/Control/Effect/Resumable.hs
+++ b/src/Control/Effect/Resumable.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
 module Control.Effect.Resumable
 ( -- * Resumable effect
   Resumable(..)
@@ -22,7 +22,7 @@ instance Effect (Resumable err) where
 -- | Throw an error which can be resumed with a value of its result type.
 --
 --   prop> run (runResumable (throwResumable (Identity a))) === Left (SomeError (Identity a))
-throwResumable :: (Member (Resumable err) (Signature m), Algebra m) => err a -> m a
+throwResumable :: m `Handles` Resumable err => err a -> m a
 throwResumable err = send (Resumable err pure)
 
 

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -22,14 +22,14 @@ data State s m k
 -- | Get the current state value.
 --
 --   prop> snd (run (runState a get)) === a
-get :: (Member (State s) sig, Algebra sig m) => m s
+get :: (Member (State s) (Signature m), Algebra m) => m s
 get = send (Get pure)
 {-# INLINEABLE get #-}
 
 -- | Project a function out of the current state value.
 --
 --   prop> snd (run (runState a (gets (applyFun f)))) === applyFun f a
-gets :: (Member (State s) sig, Algebra sig m) => (s -> a) -> m a
+gets :: (Member (State s) (Signature m), Algebra m) => (s -> a) -> m a
 gets f = send (Get (pure . f))
 {-# INLINEABLE gets #-}
 
@@ -38,7 +38,7 @@ gets f = send (Get (pure . f))
 --   prop> fst (run (runState a (put b))) === b
 --   prop> snd (run (runState a (get <* put b))) === a
 --   prop> snd (run (runState a (put b *> get))) === b
-put :: (Member (State s) sig, Algebra sig m) => s -> m ()
+put :: (Member (State s) (Signature m), Algebra m) => s -> m ()
 put s = send (Put s (pure ()))
 {-# INLINEABLE put #-}
 
@@ -46,7 +46,7 @@ put s = send (Put s (pure ()))
 --   This is strict in the new state.
 --
 --   prop> fst (run (runState a (modify (+1)))) === (1 + a :: Integer)
-modify :: (Member (State s) sig, Algebra sig m) => (s -> s) -> m ()
+modify :: (Member (State s) (Signature m), Algebra m) => (s -> s) -> m ()
 modify f = do
   a <- get
   put $! f a
@@ -54,7 +54,7 @@ modify f = do
 
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is lazy in the new state; injudicious use of this function may lead to space leaks.
-modifyLazy :: (Member (State s) sig, Algebra sig m) => (s -> s) -> m ()
+modifyLazy :: (Member (State s) (Signature m), Algebra m) => (s -> s) -> m ()
 modifyLazy f = get >>= put . f
 {-# INLINEABLE modifyLazy #-}
 

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveAnyClass, DeriveFunctor, DeriveGeneric, DerivingStrategies, ExplicitForAll, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, UndecidableInstances #-}
 module Control.Effect.State
 ( -- * State effect
   State(..)

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -22,14 +22,14 @@ data State s m k
 -- | Get the current state value.
 --
 --   prop> snd (run (runState a get)) === a
-get :: (Member (State s) (Signature m), Algebra m) => m s
+get :: m `Handles` State s => m s
 get = send (Get pure)
 {-# INLINEABLE get #-}
 
 -- | Project a function out of the current state value.
 --
 --   prop> snd (run (runState a (gets (applyFun f)))) === applyFun f a
-gets :: (Member (State s) (Signature m), Algebra m) => (s -> a) -> m a
+gets :: m `Handles` State s => (s -> a) -> m a
 gets f = send (Get (pure . f))
 {-# INLINEABLE gets #-}
 
@@ -38,7 +38,7 @@ gets f = send (Get (pure . f))
 --   prop> fst (run (runState a (put b))) === b
 --   prop> snd (run (runState a (get <* put b))) === a
 --   prop> snd (run (runState a (put b *> get))) === b
-put :: (Member (State s) (Signature m), Algebra m) => s -> m ()
+put :: m `Handles` State s => s -> m ()
 put s = send (Put s (pure ()))
 {-# INLINEABLE put #-}
 
@@ -46,7 +46,7 @@ put s = send (Put s (pure ()))
 --   This is strict in the new state.
 --
 --   prop> fst (run (runState a (modify (+1)))) === (1 + a :: Integer)
-modify :: (Member (State s) (Signature m), Algebra m) => (s -> s) -> m ()
+modify :: m `Handles` State s => (s -> s) -> m ()
 modify f = do
   a <- get
   put $! f a
@@ -54,7 +54,7 @@ modify f = do
 
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is lazy in the new state; injudicious use of this function may lead to space leaks.
-modifyLazy :: (Member (State s) (Signature m), Algebra m) => (s -> s) -> m ()
+modifyLazy :: m `Handles` State s => (s -> s) -> m ()
 modifyLazy f = get >>= put . f
 {-# INLINEABLE modifyLazy #-}
 

--- a/src/Control/Effect/State.hs
+++ b/src/Control/Effect/State.hs
@@ -22,14 +22,14 @@ data State s m k
 -- | Get the current state value.
 --
 --   prop> snd (run (runState a get)) === a
-get :: m `Handles` State s => m s
+get :: Has (State s) m => m s
 get = send (Get pure)
 {-# INLINEABLE get #-}
 
 -- | Project a function out of the current state value.
 --
 --   prop> snd (run (runState a (gets (applyFun f)))) === applyFun f a
-gets :: m `Handles` State s => (s -> a) -> m a
+gets :: Has (State s) m => (s -> a) -> m a
 gets f = send (Get (pure . f))
 {-# INLINEABLE gets #-}
 
@@ -38,7 +38,7 @@ gets f = send (Get (pure . f))
 --   prop> fst (run (runState a (put b))) === b
 --   prop> snd (run (runState a (get <* put b))) === a
 --   prop> snd (run (runState a (put b *> get))) === b
-put :: m `Handles` State s => s -> m ()
+put :: Has (State s) m => s -> m ()
 put s = send (Put s (pure ()))
 {-# INLINEABLE put #-}
 
@@ -46,7 +46,7 @@ put s = send (Put s (pure ()))
 --   This is strict in the new state.
 --
 --   prop> fst (run (runState a (modify (+1)))) === (1 + a :: Integer)
-modify :: m `Handles` State s => (s -> s) -> m ()
+modify :: Has (State s) m => (s -> s) -> m ()
 modify f = do
   a <- get
   put $! f a
@@ -54,7 +54,7 @@ modify f = do
 
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is lazy in the new state; injudicious use of this function may lead to space leaks.
-modifyLazy :: m `Handles` State s => (s -> s) -> m ()
+modifyLazy :: Has (State s) m => (s -> s) -> m ()
 modifyLazy f = get >>= put . f
 {-# INLINEABLE modifyLazy #-}
 

--- a/src/Control/Effect/State/Named.hs
+++ b/src/Control/Effect/State/Named.hs
@@ -15,14 +15,14 @@ import Control.Effect.State (State(..))
 -- | Get the current state value.
 --
 --   prop> snd (run (runState a get)) === a
-get :: forall name s m . (NamedMember name (State s) (Signature m), Algebra m) => m s
+get :: forall name s m . HasNamed name (State s) m => m s
 get = sendNamed @name (Get pure)
 {-# INLINEABLE get #-}
 
 -- | Project a function out of the current state value.
 --
 --   prop> snd (run (runState a (gets (applyFun f)))) === applyFun f a
-gets :: forall name s m a . (NamedMember name (State s) (Signature m), Algebra m) => (s -> a) -> m a
+gets :: forall name s m a . HasNamed name (State s) m => (s -> a) -> m a
 gets f = sendNamed @name (Get (pure . f))
 {-# INLINEABLE gets #-}
 
@@ -31,7 +31,7 @@ gets f = sendNamed @name (Get (pure . f))
 --   prop> fst (run (runState a (put b))) === b
 --   prop> snd (run (runState a (get <* put b))) === a
 --   prop> snd (run (runState a (put b *> get))) === b
-put :: forall name s m . (NamedMember name (State s) (Signature m), Algebra m) => s -> m ()
+put :: forall name s m . HasNamed name (State s) m => s -> m ()
 put s = sendNamed @name (Put s (pure ()))
 {-# INLINEABLE put #-}
 
@@ -39,7 +39,7 @@ put s = sendNamed @name (Put s (pure ()))
 --   This is strict in the new state.
 --
 --   prop> fst (run (runState a (modify (+1)))) === (1 + a :: Integer)
-modify :: forall name s m . (NamedMember name (State s) (Signature m), Algebra m) => (s -> s) -> m ()
+modify :: forall name s m . HasNamed name (State s) m => (s -> s) -> m ()
 modify f = do
   a <- get @name
   put @name $! f a
@@ -47,6 +47,6 @@ modify f = do
 
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is lazy in the new state; injudicious use of this function may lead to space leaks.
-modifyLazy :: forall name s m . (NamedMember name (State s) (Signature m), Algebra m) => (s -> s) -> m ()
+modifyLazy :: forall name s m . HasNamed name (State s) m => (s -> s) -> m ()
 modifyLazy f = get @name >>= put @name . f
 {-# INLINEABLE modifyLazy #-}

--- a/src/Control/Effect/State/Named.hs
+++ b/src/Control/Effect/State/Named.hs
@@ -15,14 +15,14 @@ import Control.Effect.State (State(..))
 -- | Get the current state value.
 --
 --   prop> snd (run (runState a get)) === a
-get :: forall name s m sig . (NamedMember name (State s) sig, Algebra sig m) => m s
+get :: forall name s m . (NamedMember name (State s) (Signature m), Algebra m) => m s
 get = sendNamed @name (Get pure)
 {-# INLINEABLE get #-}
 
 -- | Project a function out of the current state value.
 --
 --   prop> snd (run (runState a (gets (applyFun f)))) === applyFun f a
-gets :: forall name s m a sig . (NamedMember name (State s) sig, Algebra sig m) => (s -> a) -> m a
+gets :: forall name s m a . (NamedMember name (State s) (Signature m), Algebra m) => (s -> a) -> m a
 gets f = sendNamed @name (Get (pure . f))
 {-# INLINEABLE gets #-}
 
@@ -31,7 +31,7 @@ gets f = sendNamed @name (Get (pure . f))
 --   prop> fst (run (runState a (put b))) === b
 --   prop> snd (run (runState a (get <* put b))) === a
 --   prop> snd (run (runState a (put b *> get))) === b
-put :: forall name s m sig . (NamedMember name (State s) sig, Algebra sig m) => s -> m ()
+put :: forall name s m . (NamedMember name (State s) (Signature m), Algebra m) => s -> m ()
 put s = sendNamed @name (Put s (pure ()))
 {-# INLINEABLE put #-}
 
@@ -39,7 +39,7 @@ put s = sendNamed @name (Put s (pure ()))
 --   This is strict in the new state.
 --
 --   prop> fst (run (runState a (modify (+1)))) === (1 + a :: Integer)
-modify :: forall name s m sig . (NamedMember name (State s) sig, Algebra sig m) => (s -> s) -> m ()
+modify :: forall name s m . (NamedMember name (State s) (Signature m), Algebra m) => (s -> s) -> m ()
 modify f = do
   a <- get @name
   put @name $! f a
@@ -47,6 +47,6 @@ modify f = do
 
 -- | Replace the state value with the result of applying a function to the current state value.
 --   This is lazy in the new state; injudicious use of this function may lead to space leaks.
-modifyLazy :: forall name s m sig . (NamedMember name (State s) sig, Algebra sig m) => (s -> s) -> m ()
+modifyLazy :: forall name s m . (NamedMember name (State s) (Signature m), Algebra m) => (s -> s) -> m ()
 modifyLazy f = get @name >>= put @name . f
 {-# INLINEABLE modifyLazy #-}

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -32,7 +32,7 @@ prj = prj' @(PathTo sub sup)
 
 
 -- | Construct a request for an effect to be interpreted by some handler later on.
-send :: (Member effect sig, Algebra sig m) => effect m a -> m a
+send :: (Member effect (Signature m), Algebra m) => effect m a -> m a
 send = alg . inj
 {-# INLINE send #-}
 

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -75,7 +75,11 @@ instance MemberAt path t r => MemberAt (R path) t (l :+: r) where
   prj' (R r) = prj'  @path r
   prj' _     = Nothing
 
-instance TypeError ('ShowType t ':<>: 'Text " is not a member of " ':<>: 'ShowType u)
+type family ShowTree t where
+  ShowTree (l :+: r) = ShowTree l ':<>: 'Text ", " ':<>: ShowTree r
+  ShowTree t         = 'ShowType t
+
+instance TypeError ('ShowType t ':<>: 'Text " is not among the handled effects (" ':<>: ShowTree u ':<>: 'Text ")")
       => MemberAt Err t u where
   inj' _ = undefined
   prj' _ = undefined

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, FunctionalDependencies, PolyKinds, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PolyKinds, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum
 ( (:+:)(..)
 , Member
@@ -53,7 +53,7 @@ type family PathTo sub sup where
   PathTo t t         = ()
   PathTo t (l :+: r) = FromJust (PathTo' L t l <|> PathTo' R t r)
 
-class MemberAt path (sub :: (* -> *) -> (* -> *)) sup | path sup -> sub where
+class MemberAt path (sub :: (* -> *) -> (* -> *)) sup where
   inj' :: sub m a -> sup m a
   prj' :: sup m a -> Maybe (sub m a)
 

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -1,14 +1,11 @@
-{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, DataKinds, DeriveGeneric, DeriveTraversable, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PolyKinds, ScopedTypeVariables, TypeApplications, TypeFamilies, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric, DeriveTraversable, FlexibleInstances, KindSignatures, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum
 ( (:+:)(..)
-, Member
-, inj
-, prj
+, Member(..)
 ) where
 
 import Control.Effect.Class
 import GHC.Generics (Generic1)
-import GHC.TypeLits (ErrorMessage(..), TypeError)
 
 data (f :+: g) (m :: * -> *) k
   = L (f m k)
@@ -21,65 +18,35 @@ instance (HFunctor f, HFunctor g) => HFunctor (f :+: g)
 instance (Effect f, Effect g)     => Effect   (f :+: g)
 
 
-type Member (sub :: (* -> *) -> (* -> *)) sup = MemberAt (PathTo sub sup) sub sup
+class Member (sub :: (* -> *) -> (* -> *)) sup where
+  inj :: sub m a -> sup m a
+  prj :: sup m a -> Maybe (sub m a)
 
-inj :: forall sub m a sup . Member sub sup => sub m a -> sup m a
-inj = inj' @(PathTo sub sup)
+instance Member sub sub where
+  inj = id
+  prj = Just
 
-prj :: forall sub m a sup . Member sub sup => sup m a -> Maybe (sub m a)
-prj = prj' @(PathTo sub sup)
+instance {-# OVERLAPPABLE #-}
+         Member sub (l1 :+: l2 :+: r)
+      => Member sub ((l1 :+: l2) :+: r) where
+  inj = reassoc . inj where
+    reassoc (L l)     = L (L l)
+    reassoc (R (L l)) = L (R l)
+    reassoc (R (R r)) = R r
+  prj = prj . reassoc where
+    reassoc (L (L l)) = L l
+    reassoc (L (R l)) = R (L l)
+    reassoc (R r)     = R (R r)
 
+instance {-# OVERLAPPABLE #-}
+         Member sub (sub :+: r) where
+  inj = L
+  prj (L l) = Just l
+  prj _     = Nothing
 
-type family FromMaybe (x :: a) (maybe :: Maybe a) :: a where
-  FromMaybe _ ('Just a) = a
-  FromMaybe a 'Nothing  = a
-
-type family (left :: Maybe k) <|> (right :: Maybe k) :: Maybe k where
-  'Just a <|> _       = 'Just a
-  _       <|> 'Just b = 'Just b
-  _       <|> _       = 'Nothing
-
-type family Prepend (s :: j -> k) (ss :: Maybe j) :: Maybe k where
-  Prepend s ('Just ss) = 'Just (s ss)
-  Prepend _ 'Nothing   = 'Nothing
-
-data L a
-data R a
-data Err
-
-type family PathTo' (side :: * -> *) (sub :: (* -> *) -> (* -> *)) sup :: Maybe * where
-  PathTo' s t t         = 'Just (s ())
-  PathTo' s t (l :+: r) = Prepend s (PathTo' L t l <|> PathTo' R t r)
-  PathTo' _ _ _         = 'Nothing
-
-type family PathTo sub sup where
-  PathTo t t         = ()
-  PathTo t (l :+: r) = FromMaybe Err (PathTo' L t l <|> PathTo' R t r)
-  PathTo _ _         = Err
-
-class MemberAt path (sub :: (* -> *) -> (* -> *)) sup where
-  inj' :: sub m a -> sup m a
-  prj' :: sup m a -> Maybe (sub m a)
-
-instance MemberAt () t t where
-  inj' = id
-  prj' = Just
-
-instance MemberAt path t l => MemberAt (L path) t (l :+: r) where
-  inj' = L . inj' @path
-  prj' (L l) = prj'  @path l
-  prj' _     = Nothing
-
-instance MemberAt path t r => MemberAt (R path) t (l :+: r) where
-  inj' = R . inj' @path
-  prj' (R r) = prj'  @path r
-  prj' _     = Nothing
-
-type family ShowTree t where
-  ShowTree (l :+: r) = ShowTree l ':<>: 'Text ", " ':<>: ShowTree r
-  ShowTree t         = 'ShowType t
-
-instance TypeError ('ShowType t ':<>: 'Text " is not among the handled effects (" ':<>: ShowTree u ':<>: 'Text ")")
-      => MemberAt Err t u where
-  inj' _ = undefined
-  prj' _ = undefined
+instance {-# OVERLAPPABLE #-}
+         Member sub r
+      => Member sub (l :+: r) where
+  inj = R . inj
+  prj (R r) = prj r
+  prj _     = Nothing

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -4,10 +4,8 @@ module Control.Effect.Sum
 , Member
 , inj
 , prj
-, send
 ) where
 
-import Control.Algebra.Class
 import Control.Effect.Class
 import GHC.Generics (Generic1)
 
@@ -29,12 +27,6 @@ inj = inj' @(PathTo sub sup)
 
 prj :: forall sub m a sup . Member sub sup => sup m a -> Maybe (sub m a)
 prj = prj' @(PathTo sub sup)
-
-
--- | Construct a request for an effect to be interpreted by some handler later on.
-send :: (Member effect (Signature m), Algebra m) => effect m a -> m a
-send = alg . inj
-{-# INLINE send #-}
 
 
 type family FromJust (maybe :: Maybe a) :: a where

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -57,8 +57,6 @@ type family PathTo sub sup where
   PathTo t (l :+: r) = FromMaybe Err (PathTo' L t l <|> PathTo' R t r)
   PathTo _ _         = Err
 
-type Parens t = 'Text "(" ':<>: t ':<>: 'Text ")"
-
 class MemberAt path (sub :: (* -> *) -> (* -> *)) sup where
   inj' :: sub m a -> sup m a
   prj' :: sup m a -> Maybe (sub m a)
@@ -77,7 +75,7 @@ instance MemberAt path t r => MemberAt (R path) t (l :+: r) where
   prj' (R r) = prj'  @path r
   prj' _     = Nothing
 
-instance TypeError (Parens ('ShowType t) ':<>: 'Text " is not a member of " ':<>: Parens ('ShowType u))
+instance TypeError ('ShowType t ':<>: 'Text " is not a member of " ':<>: 'ShowType u)
       => MemberAt Err t u where
   inj' _ = undefined
   prj' _ = undefined

--- a/src/Control/Effect/Sum.hs
+++ b/src/Control/Effect/Sum.hs
@@ -45,7 +45,7 @@ type family Prepend (s :: j -> k) (ss :: Maybe j) :: Maybe k where
 
 data L a
 data R a
-data E a
+data Err
 
 type family PathTo' (side :: * -> *) (sub :: (* -> *) -> (* -> *)) sup :: Maybe * where
   PathTo' s t t         = 'Just (s ())
@@ -54,8 +54,8 @@ type family PathTo' (side :: * -> *) (sub :: (* -> *) -> (* -> *)) sup :: Maybe 
 
 type family PathTo sub sup where
   PathTo t t         = ()
-  PathTo t (l :+: r) = FromMaybe (E (Parens ('ShowType t) ':<>: 'Text " is not a member of " ':<>: Parens ('ShowType (l :+: r)))) (PathTo' L t l <|> PathTo' R t r)
-  PathTo t s         = E (Parens ('ShowType t) ':<>: 'Text " is not a member of " ':<>: Parens ('ShowType s))
+  PathTo t (l :+: r) = FromMaybe Err (PathTo' L t l <|> PathTo' R t r)
+  PathTo _ _         = Err
 
 type Parens t = 'Text "(" ':<>: t ':<>: 'Text ")"
 
@@ -77,6 +77,7 @@ instance MemberAt path t r => MemberAt (R path) t (l :+: r) where
   prj' (R r) = prj'  @path r
   prj' _     = Nothing
 
-instance TypeError err => MemberAt (E err) t u where
+instance TypeError (Parens ('ShowType t) ':<>: 'Text " is not a member of " ':<>: Parens ('ShowType u))
+      => MemberAt Err t u where
   inj' _ = undefined
   prj' _ = undefined

--- a/src/Control/Effect/Sum/Named.hs
+++ b/src/Control/Effect/Sum/Named.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE AllowAmbiguousTypes, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, PolyKinds, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, ConstraintKinds, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, PolyKinds, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum.Named
 ( Named(..)
 , NamedMember(..)
+, HasNamed
 , sendNamed
 ) where
 
@@ -24,7 +25,14 @@ instance {-# OVERLAPPABLE #-} NamedMember name sub sup => NamedMember name sub (
   injNamed = R . injNamed
 
 
+type HasNamed name eff m = (Algebra m, HasNamedIn name (Signature m) eff)
+
 -- | Construct a request for a named effect to be interpreted by some handler later on.
-sendNamed :: forall name effect m a . (NamedMember name effect (Signature m), Algebra m) => effect m a -> m a
+sendNamed :: forall name eff m a . HasNamed name eff m => eff m a -> m a
 sendNamed = alg . injNamed . Named @name
 {-# INLINE sendNamed #-}
+
+
+class NamedMember name eff sig => HasNamedIn name sig eff
+instance {-# OVERLAPPABLE #-} HasNamedIn name (Named name eff) eff
+instance {-# OVERLAPPABLE #-} NamedMember name eff (l :+: r) => HasNamedIn name (l :+: r) eff

--- a/src/Control/Effect/Sum/Named.hs
+++ b/src/Control/Effect/Sum/Named.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, PolyKinds, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GeneralizedNewtypeDeriving, PolyKinds, ScopedTypeVariables, TypeApplications, TypeOperators, UndecidableInstances #-}
 module Control.Effect.Sum.Named
 ( Named(..)
 , NamedMember(..)
@@ -25,6 +25,6 @@ instance {-# OVERLAPPABLE #-} NamedMember name sub sup => NamedMember name sub (
 
 
 -- | Construct a request for a named effect to be interpreted by some handler later on.
-sendNamed :: forall name effect sig m a . (NamedMember name effect sig, Algebra sig m) => effect m a -> m a
+sendNamed :: forall name effect m a . (NamedMember name effect (Signature m), Algebra m) => effect m a -> m a
 sendNamed = alg . injNamed . Named @name
 {-# INLINE sendNamed #-}

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, TypeOperators #-}
 module Control.Effect.Trace
 ( -- * Trace effect
   Trace(..)
@@ -18,5 +18,5 @@ instance HFunctor Trace
 instance Effect   Trace
 
 -- | Append a message to the trace log.
-trace :: (Member Trace (Signature m), Algebra m) => String -> m ()
+trace :: m `Handles` Trace => String -> m ()
 trace message = send (Trace message (pure ()))

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -18,5 +18,5 @@ instance HFunctor Trace
 instance Effect   Trace
 
 -- | Append a message to the trace log.
-trace :: (Member Trace sig, Algebra sig m) => String -> m ()
+trace :: (Member Trace (Signature m), Algebra m) => String -> m ()
 trace message = send (Trace message (pure ()))

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric, FlexibleContexts #-}
 module Control.Effect.Trace
 ( -- * Trace effect
   Trace(..)

--- a/src/Control/Effect/Trace.hs
+++ b/src/Control/Effect/Trace.hs
@@ -18,5 +18,5 @@ instance HFunctor Trace
 instance Effect   Trace
 
 -- | Append a message to the trace log.
-trace :: m `Handles` Trace => String -> m ()
+trace :: Has Trace m => String -> m ()
 trace message = send (Trace message (pure ()))

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
 module Control.Effect.Writer
 ( -- * Writer effect
   Writer(..)

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving #-}
+{-# LANGUAGE DeriveFunctor, ExistentialQuantification, FlexibleContexts, StandaloneDeriving, TypeOperators #-}
 module Control.Effect.Writer
 ( -- * Writer effect
   Writer(..)
@@ -32,21 +32,21 @@ instance Effect (Writer w) where
 -- | Write a value to the log.
 --
 --   prop> fst (run (runWriter (mapM_ (tell . Sum) (0 : ws)))) === foldMap Sum ws
-tell :: (Member (Writer w) (Signature m), Algebra m) => w -> m ()
+tell :: m `Handles` Writer w => w -> m ()
 tell w = send (Tell w (pure ()))
 {-# INLINE tell #-}
 
 -- | Run a computation, returning the pair of its output and its result.
 --
 --   prop> run (runWriter (fst <$ tell (Sum a) <*> listen @(Sum Integer) (tell (Sum b)))) === (Sum a <> Sum b, Sum b)
-listen :: (Member (Writer w) (Signature m), Algebra m) => m a -> m (w, a)
+listen :: m `Handles` Writer w => m a -> m (w, a)
 listen m = send (Listen m (curry pure))
 {-# INLINE listen #-}
 
 -- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
 --
 --   prop> run (runWriter (fst <$ tell (Sum a) <*> listens @(Sum Integer) (applyFun f) (tell (Sum b)))) === (Sum a <> Sum b, applyFun f (Sum b))
-listens :: (Member (Writer w) (Signature m), Algebra m) => (w -> b) -> m a -> m (b, a)
+listens :: m `Handles` Writer w => (w -> b) -> m a -> m (b, a)
 listens f m = send (Listen m (curry pure . f))
 {-# INLINE listens #-}
 
@@ -54,7 +54,7 @@ listens f m = send (Listen m (curry pure . f))
 --
 --   prop> run (execWriter (censor (applyFun f) (tell (Sum a)))) === applyFun f (Sum a)
 --   prop> run (execWriter (tell (Sum a) *> censor (applyFun f) (tell (Sum b)) *> tell (Sum c))) === (Sum a <> applyFun f (Sum b) <> Sum c)
-censor :: (Member (Writer w) (Signature m), Algebra m) => (w -> w) -> m a -> m a
+censor :: m `Handles` Writer w => (w -> w) -> m a -> m a
 censor f m = send (Censor f m pure)
 {-# INLINE censor #-}
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -32,21 +32,21 @@ instance Effect (Writer w) where
 -- | Write a value to the log.
 --
 --   prop> fst (run (runWriter (mapM_ (tell . Sum) (0 : ws)))) === foldMap Sum ws
-tell :: (Member (Writer w) sig, Algebra sig m) => w -> m ()
+tell :: (Member (Writer w) (Signature m), Algebra m) => w -> m ()
 tell w = send (Tell w (pure ()))
 {-# INLINE tell #-}
 
 -- | Run a computation, returning the pair of its output and its result.
 --
 --   prop> run (runWriter (fst <$ tell (Sum a) <*> listen @(Sum Integer) (tell (Sum b)))) === (Sum a <> Sum b, Sum b)
-listen :: (Member (Writer w) sig, Algebra sig m) => m a -> m (w, a)
+listen :: (Member (Writer w) (Signature m), Algebra m) => m a -> m (w, a)
 listen m = send (Listen m (curry pure))
 {-# INLINE listen #-}
 
 -- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
 --
 --   prop> run (runWriter (fst <$ tell (Sum a) <*> listens @(Sum Integer) (applyFun f) (tell (Sum b)))) === (Sum a <> Sum b, applyFun f (Sum b))
-listens :: (Member (Writer w) sig, Algebra sig m) => (w -> b) -> m a -> m (b, a)
+listens :: (Member (Writer w) (Signature m), Algebra m) => (w -> b) -> m a -> m (b, a)
 listens f m = send (Listen m (curry pure . f))
 {-# INLINE listens #-}
 
@@ -54,7 +54,7 @@ listens f m = send (Listen m (curry pure . f))
 --
 --   prop> run (execWriter (censor (applyFun f) (tell (Sum a)))) === applyFun f (Sum a)
 --   prop> run (execWriter (tell (Sum a) *> censor (applyFun f) (tell (Sum b)) *> tell (Sum c))) === (Sum a <> applyFun f (Sum b) <> Sum c)
-censor :: (Member (Writer w) sig, Algebra sig m) => (w -> w) -> m a -> m a
+censor :: (Member (Writer w) (Signature m), Algebra m) => (w -> w) -> m a -> m a
 censor f m = send (Censor f m pure)
 {-# INLINE censor #-}
 

--- a/src/Control/Effect/Writer.hs
+++ b/src/Control/Effect/Writer.hs
@@ -32,21 +32,21 @@ instance Effect (Writer w) where
 -- | Write a value to the log.
 --
 --   prop> fst (run (runWriter (mapM_ (tell . Sum) (0 : ws)))) === foldMap Sum ws
-tell :: m `Handles` Writer w => w -> m ()
+tell :: Has (Writer w) m => w -> m ()
 tell w = send (Tell w (pure ()))
 {-# INLINE tell #-}
 
 -- | Run a computation, returning the pair of its output and its result.
 --
 --   prop> run (runWriter (fst <$ tell (Sum a) <*> listen @(Sum Integer) (tell (Sum b)))) === (Sum a <> Sum b, Sum b)
-listen :: m `Handles` Writer w => m a -> m (w, a)
+listen :: Has (Writer w) m => m a -> m (w, a)
 listen m = send (Listen m (curry pure))
 {-# INLINE listen #-}
 
 -- | Run a computation, applying a function to its output and returning the pair of the modified output and its result.
 --
 --   prop> run (runWriter (fst <$ tell (Sum a) <*> listens @(Sum Integer) (applyFun f) (tell (Sum b)))) === (Sum a <> Sum b, applyFun f (Sum b))
-listens :: m `Handles` Writer w => (w -> b) -> m a -> m (b, a)
+listens :: Has (Writer w) m => (w -> b) -> m a -> m (b, a)
 listens f m = send (Listen m (curry pure . f))
 {-# INLINE listens #-}
 
@@ -54,7 +54,7 @@ listens f m = send (Listen m (curry pure . f))
 --
 --   prop> run (execWriter (censor (applyFun f) (tell (Sum a)))) === applyFun f (Sum a)
 --   prop> run (execWriter (tell (Sum a) *> censor (applyFun f) (tell (Sum b)) *> tell (Sum c))) === (Sum a <> applyFun f (Sum b) <> Sum c)
-censor :: m `Handles` Writer w => (w -> w) -> m a -> m a
+censor :: Has (Writer w) m => (w -> w) -> m a -> m a
 censor f m = send (Censor f m pure)
 {-# INLINE censor #-}
 

--- a/test/Control/Effect/NonDet/Spec.hs
+++ b/test/Control/Effect/NonDet/Spec.hs
@@ -2,9 +2,9 @@ module Control.Effect.NonDet.Spec
 ( spec
 ) where
 
-import Control.Effect.Error
-import Control.Effect.NonDet
-import Control.Effect.State
+import Control.Algebra.Error.Either
+import Control.Algebra.NonDet.Church
+import Control.Algebra.State.Strict
 import Test.Hspec
 
 spec :: Spec

--- a/test/Control/Effect/Spec.hs
+++ b/test/Control/Effect/Spec.hs
@@ -5,10 +5,11 @@ module Control.Effect.Spec
 ) where
 
 import Control.Algebra
-import Control.Effect.Error
-import Control.Effect.Fail
-import Control.Effect.Reader
-import Control.Effect.State
+import Control.Algebra.Error.Either
+import Control.Algebra.Fail
+import Control.Algebra.Reader
+import Control.Algebra.State.Strict
+import Control.Effect.Sum
 import Prelude hiding (fail)
 import Test.Hspec
 import Test.Inspection as Inspection


### PR DESCRIPTION
Following @lexi-lambda’s suggestion, this PR models an `Algebra`’s effect signature using an associated type family instead of a functional dependency. This allows us to reduce the context of an effectful action like `tell` from a combination of `Algebra` and `Member` constraints:

```haskell
tell :: (Member (Writer w) sig, Algebra sig m) => w -> m ()
```

down to one or more `Has` constraints:

```haskell
tell :: Has (Writer w) m => w -> m ()
```