### PR TITLE
Algebra transformers

### DIFF
--- a/diffused-effects.cabal
+++ b/diffused-effects.cabal
@@ -38,6 +38,7 @@ library
   import: common
   exposed-modules:
     Algebra
+    Algebra.Trans
     Algebra.Choose.Church
     Algebra.Cull.Church
     Algebra.Cut.Church

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Algebra.Trans
 ( Algebra(..)
+, MonadLift(..)
 , AlgebraTrans(..)
 , AlgT(..)
 , algDefault

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -5,7 +5,6 @@ module Algebra.Trans
 ( AlgebraTrans(..)
 ) where
 
-import qualified Algebra as A
 import           Control.Monad.Trans.Class
 import qualified Control.Monad.Trans.Reader as R
 import           Effect.Reader.Internal
@@ -13,7 +12,7 @@ import           Effect.Reader.Internal
 class MonadTrans t => AlgebraTrans t where
   type SigT t :: (* -> *) -> (* -> *)
 
-  algT :: A.Algebra m => SigT t (t m) a -> t m a
+  algT :: Monad m => SigT t (t m) a -> t m a
 
 instance AlgebraTrans (R.ReaderT r) where
   type SigT (R.ReaderT r) = Reader r

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 module Algebra.Trans
 ( AlgebraTrans(..)
@@ -7,3 +8,5 @@ import Control.Monad.Trans.Class
 
 class MonadTrans t => AlgebraTrans t where
   type SigT t :: (* -> *) -> (* -> *)
+
+  algT :: (Functor ctx, Monad m) => ctx () -> (forall x . ctx (n x) -> t m (ctx x)) -> SigT t n a -> t m (ctx a)

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -36,13 +36,13 @@ class Monad m => Algebra m where
 
   alg :: Functor ctx => ctx () -> (forall x . ctx (n x) -> m (ctx x)) -> Sig m n a -> m (ctx a)
 
+class MonadTrans t => MonadLift t where
+  liftWith :: Monad m => (forall ctx . Functor ctx => ctx () -> (forall a . ctx (t m a) -> m (ctx a)) -> m (ctx a)) -> t m a
 
-class (MonadTrans t, Algebra m, Monad (t m)) => AlgebraTrans t m where
+class (MonadLift t, Algebra m, Monad (t m)) => AlgebraTrans t m where
   type SigT t :: (Type -> Type) -> (Type -> Type)
 
   algT :: Functor ctx => ctx () -> (forall a . ctx (n a) -> t m (ctx a)) -> SigT t n a -> t m (ctx a)
-
-  liftWith :: (forall ctx . Functor ctx => ctx () -> (forall a . ctx (t m a) -> m (ctx a)) -> m (ctx a)) -> t m a
 
 
 newtype AlgT t (m :: Type -> Type) a = AlgT { runAlgT :: t m a }
@@ -59,6 +59,9 @@ algDefault ctx1 hdl1 = \case
   R r -> liftWith $ \ ctx2 hdl2 -> getCompose <$> alg (Compose (ctx1 <$ ctx2)) (fmap Compose . hdl2 . fmap hdl1 . getCompose) r
 
 
+instance MonadLift (R.ReaderT r) where
+  liftWith f = R.ReaderT $ \ r -> runIdentity <$> f (Identity ()) (fmap Identity . (`R.runReaderT` r) . runIdentity)
+
 instance Algebra m => AlgebraTrans (R.ReaderT r) m where
   type SigT (R.ReaderT r) = Reader r
 
@@ -66,9 +69,10 @@ instance Algebra m => AlgebraTrans (R.ReaderT r) m where
     Ask       k -> R.ask                      >>= hdl . (<$ ctx) . k
     Local f m k -> R.local f (hdl (m <$ ctx)) >>= hdl . fmap k
 
-  liftWith f = R.ReaderT $ \ r -> runIdentity <$> f (Identity ()) (fmap Identity . (`R.runReaderT` r) . runIdentity)
-
 deriving via AlgT (R.ReaderT r) m instance Algebra m => Algebra (R.ReaderT r m)
+
+instance MonadLift (E.ExceptT e) where
+  liftWith f = E.ExceptT $ f (Right ()) (either (pure . Left) E.runExceptT)
 
 instance Algebra m => AlgebraTrans (E.ExceptT e) m where
   type SigT (E.ExceptT e) = Error e
@@ -77,9 +81,10 @@ instance Algebra m => AlgebraTrans (E.ExceptT e) m where
     L (Throw e)     -> E.throwE e
     R (Catch m h k) -> E.catchE (hdl (m <$ ctx)) (hdl . (<$ ctx) . h) >>= hdl . fmap k
 
-  liftWith f = E.ExceptT $ f (Right ()) (either (pure . Left) E.runExceptT)
-
 deriving via AlgT (E.ExceptT e) m instance Algebra m => Algebra (E.ExceptT e m)
+
+instance MonadLift (S.L.StateT s) where
+  liftWith f = S.L.StateT $ \ s -> swap <$> f (s, ()) (fmap swap . uncurry (flip S.L.runStateT))
 
 instance Algebra m => AlgebraTrans (S.L.StateT s) m where
   type SigT (S.L.StateT s) = State s
@@ -88,9 +93,10 @@ instance Algebra m => AlgebraTrans (S.L.StateT s) m where
     Get   k -> S.L.get   >>= hdl . (<$ ctx) . k
     Put s k -> S.L.put s >>  hdl (k <$ ctx)
 
-  liftWith f = S.L.StateT $ \ s -> swap <$> f (s, ()) (fmap swap . uncurry (flip S.L.runStateT))
-
 deriving via AlgT (S.L.StateT s) m instance Algebra m => Algebra (S.L.StateT s m)
+
+instance MonadLift (S.S.StateT s) where
+  liftWith f = S.S.StateT $ \ s -> swap <$> f (s, ()) (fmap swap . uncurry (flip S.S.runStateT))
 
 instance Algebra m => AlgebraTrans (S.S.StateT s) m where
   type SigT (S.S.StateT s) = State s
@@ -98,7 +104,5 @@ instance Algebra m => AlgebraTrans (S.S.StateT s) m where
   algT ctx hdl = \case
     Get   k -> S.S.get   >>= hdl . (<$ ctx) . k
     Put s k -> S.S.put s >>  hdl (k <$ ctx)
-
-  liftWith f = S.S.StateT $ \ s -> swap <$> f (s, ()) (fmap swap . uncurry (flip S.S.runStateT))
 
 deriving via AlgT (S.S.StateT s) m instance Algebra m => Algebra (S.S.StateT s m)

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 module Algebra.Trans
@@ -6,8 +7,17 @@ module Algebra.Trans
 
 import qualified Algebra as A
 import           Control.Monad.Trans.Class
+import qualified Control.Monad.Trans.Reader as R
+import           Effect.Reader.Internal
 
 class MonadTrans t => AlgebraTrans t where
   type SigT t :: (* -> *) -> (* -> *)
 
   algT :: A.Algebra m => SigT t (t m) a -> t m a
+
+instance AlgebraTrans (R.ReaderT r) where
+  type SigT (R.ReaderT r) = Reader r
+
+  algT = \case
+    Ask       k -> R.ask       >>= k
+    Local f m k -> R.local f m >>= k

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -37,7 +37,7 @@ instance AlgebraTrans (R.ReaderT r) where
     Ask       k -> R.ask       >>= k
     Local f m k -> R.local f m >>= k
 
-  liftWith f = R.ReaderT (\ r -> runIdentity <$> f (Identity ()) (fmap Identity . (`R.runReaderT` r) . runIdentity))
+  liftWith f = R.ReaderT $ \ r -> runIdentity <$> f (Identity ()) (fmap Identity . (`R.runReaderT` r) . runIdentity)
 
 instance AlgebraTrans (E.ExceptT e) where
   type SigT (E.ExceptT e) = Error e

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE TypeFamilies #-}
 module Algebra.Trans
-( AlgebraTrans
+( AlgebraTrans(..)
 ) where
 
 import Control.Monad.Trans.Class
 
-class MonadTrans t => AlgebraTrans t
+class MonadTrans t => AlgebraTrans t where
+  type SigT t :: (* -> *) -> (* -> *)

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -25,6 +25,7 @@ class MonadTrans t => AlgebraTrans t where
 
   algT :: Monad m => SigT t (t m) a -> t m a
 
+
 instance AlgebraTrans (R.ReaderT r) where
   type SigT (R.ReaderT r) = Reader r
 

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -6,8 +6,13 @@ module Algebra.Trans
 ) where
 
 import           Control.Monad.Trans.Class
+import qualified Control.Monad.Trans.Except as E
 import qualified Control.Monad.Trans.Reader as R
+import           Effect.Catch.Internal
+import           Effect.Error.Internal
 import           Effect.Reader.Internal
+import           Effect.Sum
+import           Effect.Throw.Internal
 
 class MonadTrans t => AlgebraTrans t where
   type SigT t :: (* -> *) -> (* -> *)
@@ -20,3 +25,10 @@ instance AlgebraTrans (R.ReaderT r) where
   algT = \case
     Ask       k -> R.ask       >>= k
     Local f m k -> R.local f m >>= k
+
+instance AlgebraTrans (E.ExceptT e) where
+  type SigT (E.ExceptT e) = Error e
+
+  algT = \case
+    L (Throw e)     -> E.throwE e
+    R (Catch m h k) -> E.catchE m h >>= k

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -1,2 +1,7 @@
 module Algebra.Trans
-() where
+( AlgebraTrans
+) where
+
+import Control.Monad.Trans.Class
+
+class MonadTrans t => AlgebraTrans t

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -8,6 +8,7 @@ module Algebra.Trans
 import           Control.Monad.Trans.Class
 import qualified Control.Monad.Trans.Except as E
 import qualified Control.Monad.Trans.Reader as R
+import           Data.Kind (Type)
 import           Effect.Catch.Internal
 import           Effect.Error.Internal
 import           Effect.Reader.Internal
@@ -15,7 +16,7 @@ import           Effect.Sum
 import           Effect.Throw.Internal
 
 class MonadTrans t => AlgebraTrans t where
-  type SigT t :: (* -> *) -> (* -> *)
+  type SigT t :: (Type -> Type) -> (Type -> Type)
 
   algT :: Monad m => SigT t (t m) a -> t m a
 

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -34,7 +34,7 @@ class Monad m => Algebra m where
   alg :: Functor ctx => ctx () -> (forall x . ctx (n x) -> m (ctx x)) -> Sig m n a -> m (ctx a)
 
 
-class (MonadTrans t, Algebra m) => AlgebraTrans t m where
+class (MonadTrans t, Algebra m, Monad (t m)) => AlgebraTrans t m where
   type SigT t :: (Type -> Type) -> (Type -> Type)
 
   algT :: Functor ctx => ctx () -> (forall a . ctx (n a) -> t m (ctx a)) -> SigT t n a -> t m (ctx a)

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -10,7 +10,9 @@ import qualified Control.Monad.Trans.Except as E
 import qualified Control.Monad.Trans.Reader as R
 import qualified Control.Monad.Trans.State.Lazy as S.L
 import qualified Control.Monad.Trans.State.Strict as S.S
+import           Data.Functor.Identity
 import           Data.Kind (Type)
+import           Data.Tuple (swap)
 import           Effect.Catch.Internal
 import           Effect.Error.Internal
 import           Effect.Reader.Internal
@@ -25,6 +27,8 @@ class MonadTrans t => AlgebraTrans t where
 
   algT :: Monad m => SigT t (t m) a -> t m a
 
+  liftWith :: Monad m => (forall ctx . Functor ctx => ctx () -> (forall a . ctx (t m a) -> m (ctx a)) -> m (ctx a)) -> t m a
+
 
 instance AlgebraTrans (R.ReaderT r) where
   type SigT (R.ReaderT r) = Reader r
@@ -33,12 +37,16 @@ instance AlgebraTrans (R.ReaderT r) where
     Ask       k -> R.ask       >>= k
     Local f m k -> R.local f m >>= k
 
+  liftWith f = R.ReaderT (\ r -> runIdentity <$> f (Identity ()) (fmap Identity . (`R.runReaderT` r) . runIdentity))
+
 instance AlgebraTrans (E.ExceptT e) where
   type SigT (E.ExceptT e) = Error e
 
   algT = \case
     L (Throw e)     -> E.throwE e
     R (Catch m h k) -> E.catchE m h >>= k
+
+  liftWith f = E.ExceptT $ f (Right ()) (either (pure . Left) E.runExceptT)
 
 instance AlgebraTrans (S.L.StateT s) where
   type SigT (S.L.StateT s) = State s
@@ -47,9 +55,13 @@ instance AlgebraTrans (S.L.StateT s) where
     Get   k -> S.L.get   >>= k
     Put s k -> S.L.put s >>  k
 
+  liftWith f = S.L.StateT $ \ s -> swap <$> f (s, ()) (fmap swap . uncurry (flip S.L.runStateT))
+
 instance AlgebraTrans (S.S.StateT s) where
   type SigT (S.S.StateT s) = State s
 
   algT = \case
     Get   k -> S.S.get   >>= k
     Put s k -> S.S.put s >>  k
+
+  liftWith f = S.S.StateT $ \ s -> swap <$> f (s, ()) (fmap swap . uncurry (flip S.S.runStateT))

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -45,6 +45,11 @@ class (MonadTrans t, Algebra m, Monad (t m)) => AlgebraTrans t m where
 newtype AlgT t (m :: Type -> Type) a = AlgT { runAlgT :: t m a }
   deriving (Applicative, Functor, Monad, MonadTrans)
 
+instance AlgebraTrans t m => Algebra (AlgT t m) where
+  type Sig (AlgT t m) = SigT t :+: Sig m
+
+  alg ctx hdl = AlgT . algDefault ctx (runAlgT . hdl)
+
 algDefault :: AlgebraTrans t m => Functor ctx => ctx () -> (forall a . ctx (n a) -> t m (ctx a)) -> (SigT t :+: Sig m) n a -> t m (ctx a)
 algDefault ctx1 hdl1 = \case
   L l -> algT ctx1 hdl1 l

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -8,11 +8,13 @@ module Algebra.Trans
 import           Control.Monad.Trans.Class
 import qualified Control.Monad.Trans.Except as E
 import qualified Control.Monad.Trans.Reader as R
+import qualified Control.Monad.Trans.State.Strict as S.S
 import           Data.Kind (Type)
 import           Effect.Catch.Internal
 import           Effect.Error.Internal
 import           Effect.Reader.Internal
 import           Effect.Sum
+import           Effect.State.Internal
 import           Effect.Throw.Internal
 
 -- FIXME: can’t express non-orthogonal algebras
@@ -35,3 +37,10 @@ instance AlgebraTrans (E.ExceptT e) where
   algT = \case
     L (Throw e)     -> E.throwE e
     R (Catch m h k) -> E.catchE m h >>= k
+
+instance AlgebraTrans (S.S.StateT s) where
+  type SigT (S.S.StateT s) = State s
+
+  algT = \case
+    Get   k -> S.S.get   >>= k
+    Put s k -> S.S.put s >>  k

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -4,9 +4,10 @@ module Algebra.Trans
 ( AlgebraTrans(..)
 ) where
 
-import Control.Monad.Trans.Class
+import qualified Algebra as A
+import           Control.Monad.Trans.Class
 
 class MonadTrans t => AlgebraTrans t where
   type SigT t :: (* -> *) -> (* -> *)
 
-  algT :: (Functor ctx, Monad m) => ctx () -> (forall x . ctx (n x) -> t m (ctx x)) -> SigT t n a -> t m (ctx a)
+  algT :: A.Algebra m => SigT t (t m) a -> t m (ctx a)

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -10,4 +10,4 @@ import           Control.Monad.Trans.Class
 class MonadTrans t => AlgebraTrans t where
   type SigT t :: (* -> *) -> (* -> *)
 
-  algT :: A.Algebra m => SigT t (t m) a -> t m (ctx a)
+  algT :: A.Algebra m => SigT t (t m) a -> t m a

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -11,6 +11,7 @@
 module Algebra.Trans
 ( Algebra(..)
 , MonadLift(..)
+, liftDefault
 , AlgebraTrans(..)
 , AlgT(..)
 , algDefault
@@ -39,6 +40,9 @@ class Monad m => Algebra m where
 
 class MonadTrans t => MonadLift t where
   liftWith :: Monad m => (forall ctx . Functor ctx => ctx () -> (forall a . ctx (t m a) -> m (ctx a)) -> m (ctx a)) -> t m a
+
+liftDefault :: (MonadLift t, Monad m) => m a -> t m a
+liftDefault m = liftWith (\ ctx _ -> (<$ ctx) <$> m)
 
 class (MonadLift t, Algebra m, Monad (t m)) => AlgebraTrans t m where
   type SigT t :: (Type -> Type) -> (Type -> Type)

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -8,6 +8,7 @@ module Algebra.Trans
 import           Control.Monad.Trans.Class
 import qualified Control.Monad.Trans.Except as E
 import qualified Control.Monad.Trans.Reader as R
+import qualified Control.Monad.Trans.State.Lazy as S.L
 import qualified Control.Monad.Trans.State.Strict as S.S
 import           Data.Kind (Type)
 import           Effect.Catch.Internal
@@ -37,6 +38,13 @@ instance AlgebraTrans (E.ExceptT e) where
   algT = \case
     L (Throw e)     -> E.throwE e
     R (Catch m h k) -> E.catchE m h >>= k
+
+instance AlgebraTrans (S.L.StateT s) where
+  type SigT (S.L.StateT s) = State s
+
+  algT = \case
+    Get   k -> S.L.get   >>= k
+    Put s k -> S.L.put s >>  k
 
 instance AlgebraTrans (S.S.StateT s) where
   type SigT (S.S.StateT s) = State s

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -25,7 +25,7 @@ import           Effect.Throw.Internal
 class MonadTrans t => AlgebraTrans t where
   type SigT t :: (Type -> Type) -> (Type -> Type)
 
-  algT :: Monad m => SigT t (t m) a -> t m a
+  algT :: (Monad m, Functor ctx) => ctx () -> (forall a . ctx (n a) -> t m (ctx a)) -> SigT t n a -> t m (ctx a)
 
   liftWith :: Monad m => (forall ctx . Functor ctx => ctx () -> (forall a . ctx (t m a) -> m (ctx a)) -> m (ctx a)) -> t m a
 
@@ -33,35 +33,35 @@ class MonadTrans t => AlgebraTrans t where
 instance AlgebraTrans (R.ReaderT r) where
   type SigT (R.ReaderT r) = Reader r
 
-  algT = \case
-    Ask       k -> R.ask       >>= k
-    Local f m k -> R.local f m >>= k
+  algT ctx hdl = \case
+    Ask       k -> R.ask                      >>= hdl . (<$ ctx) . k
+    Local f m k -> R.local f (hdl (m <$ ctx)) >>= hdl . fmap k
 
   liftWith f = R.ReaderT $ \ r -> runIdentity <$> f (Identity ()) (fmap Identity . (`R.runReaderT` r) . runIdentity)
 
 instance AlgebraTrans (E.ExceptT e) where
   type SigT (E.ExceptT e) = Error e
 
-  algT = \case
+  algT ctx hdl = \case
     L (Throw e)     -> E.throwE e
-    R (Catch m h k) -> E.catchE m h >>= k
+    R (Catch m h k) -> E.catchE (hdl (m <$ ctx)) (hdl . (<$ ctx) . h) >>= hdl . fmap k
 
   liftWith f = E.ExceptT $ f (Right ()) (either (pure . Left) E.runExceptT)
 
 instance AlgebraTrans (S.L.StateT s) where
   type SigT (S.L.StateT s) = State s
 
-  algT = \case
-    Get   k -> S.L.get   >>= k
-    Put s k -> S.L.put s >>  k
+  algT ctx hdl = \case
+    Get   k -> S.L.get   >>= hdl . (<$ ctx) . k
+    Put s k -> S.L.put s >>  hdl (k <$ ctx)
 
   liftWith f = S.L.StateT $ \ s -> swap <$> f (s, ()) (fmap swap . uncurry (flip S.L.runStateT))
 
 instance AlgebraTrans (S.S.StateT s) where
   type SigT (S.S.StateT s) = State s
 
-  algT = \case
-    Get   k -> S.S.get   >>= k
-    Put s k -> S.S.put s >>  k
+  algT ctx hdl = \case
+    Get   k -> S.S.get   >>= hdl . (<$ ctx) . k
+    Put s k -> S.S.put s >>  hdl (k <$ ctx)
 
   liftWith f = S.S.StateT $ \ s -> swap <$> f (s, ()) (fmap swap . uncurry (flip S.S.runStateT))

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -1,0 +1,2 @@
+module Algebra.Trans
+() where

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -15,6 +15,8 @@ import           Effect.Reader.Internal
 import           Effect.Sum
 import           Effect.Throw.Internal
 
+-- FIXME: can’t express non-orthogonal algebras
+
 class MonadTrans t => AlgebraTrans t where
   type SigT t :: (Type -> Type) -> (Type -> Type)
 

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
@@ -7,6 +8,7 @@
 module Algebra.Trans
 ( Algebra(..)
 , AlgebraTrans(..)
+, AlgT(..)
 , algDefault
 ) where
 
@@ -39,6 +41,9 @@ class (MonadTrans t, Algebra m) => AlgebraTrans t m where
 
   liftWith :: (forall ctx . Functor ctx => ctx () -> (forall a . ctx (t m a) -> m (ctx a)) -> m (ctx a)) -> t m a
 
+
+newtype AlgT t (m :: Type -> Type) a = AlgT { runAlgT :: t m a }
+  deriving (Applicative, Functor, Monad, MonadTrans)
 
 algDefault :: AlgebraTrans t m => Functor ctx => ctx () -> (forall a . ctx (n a) -> t m (ctx a)) -> (SigT t :+: Sig m) n a -> t m (ctx a)
 algDefault ctx1 hdl1 = \case

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 module Algebra.Trans
-( AlgebraTrans(..)
+( Algebra(..)
+, AlgebraTrans(..)
 ) where
 
 import           Control.Monad.Trans.Class
@@ -19,6 +20,12 @@ import           Effect.Reader.Internal
 import           Effect.Sum
 import           Effect.State.Internal
 import           Effect.Throw.Internal
+
+class Monad m => Algebra m where
+  type Sig m :: (* -> *) -> (* -> *)
+
+  alg :: Functor ctx => ctx () -> (forall x . ctx (n x) -> m (ctx x)) -> Sig m n a -> m (ctx a)
+
 
 -- FIXME: can’t express non-orthogonal algebras
 


### PR DESCRIPTION
This PR introduces algebra transformers supporting non-orthogonal algebras (i.e. algebras which constrain the underlying carriers) as well as orthogonal ones. It also adds a `MonadTransControl`-like class supporting lowering and relifting of monad transformers.