### PR TITLE
Lowering category

### DIFF
--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -44,6 +44,7 @@ module Algebra.Trans
 , mapLowerC
 ) where
 
+import           Control.Category ((>>>))
 import qualified Control.Category as C
 import           Control.Monad ((<=<))
 import           Control.Monad.Trans.Class
@@ -210,7 +211,7 @@ instance Algebra m => AlgebraTrans (R.ReaderT r) m where
 
   algT = \case
     Ask       k -> lift R.ask >>= initialT . k
-    Local f m k -> mapLowerT (R.local f) (initialT m) >>= contT k
+    Local f m k -> fromLowerC $ mapLowerC (R.local f) (initialC m) >>> contC k
 
 deriving via AlgT (R.ReaderT r) m instance Algebra m => Algebra (R.ReaderT r m)
 

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -46,6 +46,7 @@ module Algebra.Trans
 , CtxC(..)
 ) where
 
+import qualified Control.Arrow as A
 import           Control.Category ((<<<), (>>>))
 import qualified Control.Category as C
 import           Control.Monad ((<=<))
@@ -184,6 +185,11 @@ instance C.Category arr => C.Category (ReaderC r arr) where
   id = ReaderC $ const C.id
 
   ReaderC f . ReaderC g = ReaderC $ \ hdl -> f hdl <<< g hdl
+
+instance A.Arrow arr => A.Arrow (ReaderC r arr) where
+  arr = ReaderC . const . A.arr
+
+  ReaderC l *** ReaderC r = ReaderC $ \ hdl -> l hdl A.*** r hdl
 
 
 newtype LowerC ctx m n a b = LowerC (Dist ctx m n -> ctx a -> n (ctx b))

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -43,6 +43,7 @@ module Algebra.Trans
 , contC
 , liftC
 , mapLowerC
+, CtxC(..)
 ) where
 
 import           Control.Category ((>>>))
@@ -206,6 +207,9 @@ liftC n = LowerC . const $ (<$> n) . ($>)
 
 mapLowerC :: (n (ctx b) -> n (ctx c)) -> LowerC ctx m n a b -> LowerC ctx m n a c
 mapLowerC f (LowerC r) = LowerC $ \ hdl -> f . r hdl
+
+
+newtype CtxC ctx n a b = CtxC (ctx a -> n (ctx b))
 
 
 instance MonadLift (R.ReaderT r) where

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -38,6 +38,7 @@ module Algebra.Trans
 , LowerC(..)
 , fromLowerT
 , fromLowerC
+, liftInitialC
 ) where
 
 import qualified Control.Category as C
@@ -182,6 +183,10 @@ fromLowerT (LowerT r) = LowerC r
 
 fromLowerC :: LowerC ctx m n () a -> LowerT ctx m n (ctx a)
 fromLowerC (LowerC r) = LowerT r
+
+
+liftInitialC :: Functor ctx => ((forall a . m a -> n (ctx a)) -> n (ctx b)) -> LowerC ctx m n () b
+liftInitialC with = LowerC $ \ hdl ctx -> with (appDist hdl . (<$ ctx))
 
 
 instance MonadLift (R.ReaderT r) where

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -36,6 +36,7 @@ module Algebra.Trans
 , liftInitial
 , liftWithin
 , LowerC(..)
+, fromLowerT
 ) where
 
 import qualified Control.Category as C
@@ -174,6 +175,9 @@ instance Monad n => C.Category (LowerC ctx m n) where
   id = LowerC $ const pure
 
   LowerC f . LowerC g = LowerC $ \ hdl -> f hdl <=< g hdl
+
+fromLowerT :: LowerT ctx m n (ctx a) -> LowerC ctx m n () a
+fromLowerT (LowerT r) = LowerC r
 
 
 instance MonadLift (R.ReaderT r) where

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -209,9 +209,9 @@ mapLowerC :: (n (ctx b) -> n (ctx c)) -> LowerC ctx m n a b -> LowerC ctx m n a 
 mapLowerC f (LowerC r) = LowerC $ \ hdl -> f . r hdl
 
 
-newtype CtxC ctx n a b = CtxC (ctx a -> n (ctx b))
+newtype CtxC ctx m a b = CtxC (ctx a -> m (ctx b))
 
-instance Monad n => C.Category (CtxC ctx n) where
+instance Monad m => C.Category (CtxC ctx m) where
   id = CtxC pure
 
   CtxC f . CtxC g = CtxC $ f <=< g

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -228,9 +228,9 @@ instance MonadLift (E.ExceptT e) where
 instance Algebra m => AlgebraTrans (E.ExceptT e) m where
   type SigT (E.ExceptT e) = Error e
 
-  algT = \case
-    L (Throw e)     -> lift (E.throwE e)
-    R (Catch m h k) -> liftInitialT (\ initialT -> E.catchE (initialT m) (initialT . h)) >>= contT k
+  algT = fromLowerC . \case
+    L (Throw e)     -> liftC (E.throwE e)
+    R (Catch m h k) -> liftInitialC (\ initialC -> E.catchE (initialC m) (initialC . h)) >>> contC k
 
 deriving via AlgT (E.ExceptT e) m instance Algebra m => Algebra (E.ExceptT e m)
 

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -41,6 +41,7 @@ module Algebra.Trans
 , initialC
 , liftInitialC
 , contC
+, liftC
 , mapLowerC
 ) where
 
@@ -52,6 +53,7 @@ import qualified Control.Monad.Trans.Except as E
 import qualified Control.Monad.Trans.Reader as R
 import qualified Control.Monad.Trans.State.Lazy as S.L
 import qualified Control.Monad.Trans.State.Strict as S.S
+import           Data.Functor (($>))
 import           Data.Functor.Compose
 import           Data.Functor.Identity
 import           Data.Kind (Type)
@@ -197,6 +199,9 @@ liftInitialC with = LowerC $ \ hdl ctx -> with (appDist hdl . (<$ ctx))
 
 contC :: Functor ctx => (a -> m b) -> LowerC ctx m n a b
 contC k = LowerC $ \ (Dist hdl) ctx -> hdl (k <$> ctx)
+
+liftC :: (Functor ctx, Functor n) => n a -> LowerC ctx m n () a
+liftC n = LowerC . const $ (<$> n) . ($>)
 
 
 mapLowerC :: (n (ctx b) -> n (ctx c)) -> LowerC ctx m n a b -> LowerC ctx m n a c

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -41,6 +41,7 @@ module Algebra.Trans
 , initialC
 , liftInitialC
 , contC
+, mapLowerC
 ) where
 
 import qualified Control.Category as C
@@ -195,6 +196,10 @@ liftInitialC with = LowerC $ \ hdl ctx -> with (appDist hdl . (<$ ctx))
 
 contC :: Functor ctx => (a -> m b) -> LowerC ctx m n a b
 contC k = LowerC $ \ (Dist hdl) ctx -> hdl (k <$> ctx)
+
+
+mapLowerC :: (n (ctx b) -> n (ctx c)) -> LowerC ctx m n a b -> LowerC ctx m n a c
+mapLowerC f (LowerC r) = LowerC $ \ hdl -> f . r hdl
 
 
 instance MonadLift (R.ReaderT r) where

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -211,6 +211,11 @@ mapLowerC f (LowerC r) = LowerC $ \ hdl -> f . r hdl
 
 newtype CtxC ctx n a b = CtxC (ctx a -> n (ctx b))
 
+instance Monad n => C.Category (CtxC ctx n) where
+  id = CtxC pure
+
+  CtxC f . CtxC g = CtxC $ f <=< g
+
 
 instance MonadLift (R.ReaderT r) where
   liftWith m = R.ReaderT $ \ r -> runIdentity <$> runLowerT (homDist (`R.runReaderT` r)) (Identity ()) m

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -40,6 +40,7 @@ module Algebra.Trans
 , fromLowerC
 , initialC
 , liftInitialC
+, contC
 ) where
 
 import qualified Control.Category as C
@@ -191,6 +192,9 @@ initialC m = liftInitialC ($ m)
 
 liftInitialC :: Functor ctx => ((forall a . m a -> n (ctx a)) -> n (ctx b)) -> LowerC ctx m n () b
 liftInitialC with = LowerC $ \ hdl ctx -> with (appDist hdl . (<$ ctx))
+
+contC :: Functor ctx => (a -> m b) -> LowerC ctx m n a b
+contC k = LowerC $ \ (Dist hdl) ctx -> hdl (k <$> ctx)
 
 
 instance MonadLift (R.ReaderT r) where

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -242,9 +242,9 @@ instance MonadLift (S.L.StateT s) where
 instance Algebra m => AlgebraTrans (S.L.StateT s) m where
   type SigT (S.L.StateT s) = State s
 
-  algT = \case
-    Get   k -> lift S.L.get     >>= initialT . k
-    Put s k -> lift (S.L.put s) >>  initialT k
+  algT = fromLowerC . \case
+    Get   k -> liftC S.L.get     >>> contC k
+    Put s k -> liftC (S.L.put s) >>> contC (const k)
 
 deriving via AlgT (S.L.StateT s) m instance Algebra m => Algebra (S.L.StateT s m)
 
@@ -256,8 +256,8 @@ instance MonadLift (S.S.StateT s) where
 instance Algebra m => AlgebraTrans (S.S.StateT s) m where
   type SigT (S.S.StateT s) = State s
 
-  algT = \case
-    Get   k -> lift S.S.get     >>= initialT . k
-    Put s k -> lift (S.S.put s) >>  initialT k
+  algT = fromLowerC . \case
+    Get   k -> liftC S.S.get     >>> contC k
+    Put s k -> liftC (S.S.put s) >>> contC (const k)
 
 deriving via AlgT (S.S.StateT s) m instance Algebra m => Algebra (S.S.StateT s m)

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -55,6 +55,7 @@ import qualified Control.Monad.Trans.Except as E
 import qualified Control.Monad.Trans.Reader as R
 import qualified Control.Monad.Trans.State.Lazy as S.L
 import qualified Control.Monad.Trans.State.Strict as S.S
+import           Data.Coerce
 import           Data.Functor (($>))
 import           Data.Functor.Compose
 import           Data.Functor.Identity
@@ -197,10 +198,10 @@ newtype LowerC ctx m n a b = LowerC (Dist ctx m n -> ctx a -> n (ctx b))
 deriving via ReaderC (Dist ctx m n) (CtxC ctx n) instance Monad n => C.Category (LowerC ctx m n)
 
 fromLowerT :: LowerT ctx m n (ctx a) -> LowerC ctx m n () a
-fromLowerT (LowerT r) = LowerC r
+fromLowerT = coerce
 
 fromLowerC :: LowerC ctx m n () a -> LowerT ctx m n (ctx a)
-fromLowerC (LowerC r) = LowerT r
+fromLowerC = coerce
 
 
 initialC :: Functor ctx => m a -> LowerC ctx m n () a

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -214,9 +214,9 @@ instance MonadLift (R.ReaderT r) where
 instance Algebra m => AlgebraTrans (R.ReaderT r) m where
   type SigT (R.ReaderT r) = Reader r
 
-  algT = \case
-    Ask       k -> lift R.ask >>= initialT . k
-    Local f m k -> fromLowerC $ mapLowerC (R.local f) (initialC m) >>> contC k
+  algT = fromLowerC . \case
+    Ask       k -> liftC R.ask >>> contC k
+    Local f m k -> mapLowerC (R.local f) (initialC m) >>> contC k
 
 deriving via AlgT (R.ReaderT r) m instance Algebra m => Algebra (R.ReaderT r m)
 

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -19,7 +19,7 @@ module Algebra.Trans
 , algDefault
 , Hom
 , runDist
-, homDist
+, hom
 , (>~>)
 , (<~<)
 , (~>)
@@ -108,8 +108,8 @@ type Hom m n = forall x . m x -> n x
 runDist :: ctx (m a) -> Dist ctx m n -> n (ctx a)
 runDist cm (Dist run) = run cm
 
-homDist :: Functor n => Hom m n -> Dist Identity m n
-homDist hom = Dist (fmap Identity . hom . runIdentity)
+hom :: Functor n => Hom m n -> Dist Identity m n
+hom hom = Dist (fmap Identity . hom . runIdentity)
 
 (>~>) :: (Functor n, Functor ctx2) => Dist ctx1 l m -> Dist ctx2 m n -> Dist (Compose ctx2 ctx1) l n
 Dist hdl1 >~> Dist hdl2 = Dist (fmap Compose . hdl2 . fmap hdl1 . getCompose)
@@ -218,7 +218,7 @@ instance Monad m => C.Category (CtxC ctx m) where
 
 
 instance MonadLift (R.ReaderT r) where
-  liftWith m = R.ReaderT $ \ r -> runIdentity <$> runLowerT (homDist (`R.runReaderT` r)) (Identity ()) m
+  liftWith m = R.ReaderT $ \ r -> runIdentity <$> runLowerT (hom (`R.runReaderT` r)) (Identity ()) m
 
 instance Algebra m => AlgebraTrans (R.ReaderT r) m where
   type SigT (R.ReaderT r) = Reader r

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -35,6 +35,7 @@ module Algebra.Trans
 , mapLowerT
 , liftInitial
 , liftWithin
+, LowerC(..)
 ) where
 
 import           Control.Monad.Trans.Class
@@ -163,6 +164,9 @@ liftInitial with = LowerT $ \ hdl ctx -> with (appDist hdl . (<$ ctx))
 
 liftWithin :: (MonadLift t, Monad m) => LowerT (Compose (Ctx t) ctx) n m (Ctx t a) -> LowerT ctx n (t m) a
 liftWithin m = LowerT $ \ hdl1 ctx1 -> liftWith $ LowerT $ \ hdl2 ctx2 -> runLowerT (hdl2 <~< hdl1) (Compose (ctx1 <$ ctx2)) m
+
+
+newtype LowerC ctx m n a b = LowerC (Dist ctx m n -> ctx a -> n (ctx b))
 
 
 instance MonadLift (R.ReaderT r) where

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -38,6 +38,8 @@ module Algebra.Trans
 , LowerC(..)
 ) where
 
+import qualified Control.Category as C
+import           Control.Monad ((<=<))
 import           Control.Monad.Trans.Class
 import qualified Control.Monad.Trans.Except as E
 import qualified Control.Monad.Trans.Reader as R
@@ -167,6 +169,11 @@ liftWithin m = LowerT $ \ hdl1 ctx1 -> liftWith $ LowerT $ \ hdl2 ctx2 -> runLow
 
 
 newtype LowerC ctx m n a b = LowerC (Dist ctx m n -> ctx a -> n (ctx b))
+
+instance Monad n => C.Category (LowerC ctx m n) where
+  id = LowerC $ const pure
+
+  LowerC f . LowerC g = LowerC $ \ hdl -> f hdl <=< g hdl
 
 
 instance MonadLift (R.ReaderT r) where

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -38,6 +38,7 @@ module Algebra.Trans
 , LowerC(..)
 , fromLowerT
 , fromLowerC
+, initialC
 , liftInitialC
 ) where
 
@@ -184,6 +185,9 @@ fromLowerT (LowerT r) = LowerC r
 fromLowerC :: LowerC ctx m n () a -> LowerT ctx m n (ctx a)
 fromLowerC (LowerC r) = LowerT r
 
+
+initialC :: Functor ctx => m a -> LowerC ctx m n () a
+initialC m = liftInitialC ($ m)
 
 liftInitialC :: Functor ctx => ((forall a . m a -> n (ctx a)) -> n (ctx b)) -> LowerC ctx m n () b
 liftInitialC with = LowerC $ \ hdl ctx -> with (appDist hdl . (<$ ctx))

--- a/src/Algebra/Trans.hs
+++ b/src/Algebra/Trans.hs
@@ -37,6 +37,7 @@ module Algebra.Trans
 , liftWithin
 , LowerC(..)
 , fromLowerT
+, fromLowerC
 ) where
 
 import qualified Control.Category as C
@@ -178,6 +179,9 @@ instance Monad n => C.Category (LowerC ctx m n) where
 
 fromLowerT :: LowerT ctx m n (ctx a) -> LowerC ctx m n () a
 fromLowerT (LowerT r) = LowerC r
+
+fromLowerC :: LowerC ctx m n () a -> LowerT ctx m n (ctx a)
+fromLowerC (LowerC r) = LowerT r
 
 
 instance MonadLift (R.ReaderT r) where


### PR DESCRIPTION
Depends on #9. Adds a lowering category that works like `LowerT`, except representing the context functor implicitly, most clearly visible in the types of `initial{T,C}` & `cont{T,C}`:

```haskell
initialT :: Functor ctx => m a -> LowerT ctx m n    (ctx a)
initialC :: Functor ctx => m a -> LowerC ctx m n ()      a

contT :: Functor ctx => (a -> m b) -> ctx a -> LowerT ctx m n   (ctx b)
contC :: Functor ctx => (a -> m b)          -> LowerC ctx m n a      b
```

This is cool, but it makes some of the constructions a little weird, and the convenience of `lift` means that `LowerT` is almost certainly the more comprehensible option.